### PR TITLE
Add optional agent ID to config

### DIFF
--- a/vijil_dome/Dome.py
+++ b/vijil_dome/Dome.py
@@ -26,9 +26,15 @@ from pydantic import BaseModel
 
 
 class DomeConfig(GuardrailConfig):
-    def __init__(self, input_guardrail: Guardrail, output_guardrail: Guardrail):
+    def __init__(
+        self,
+        input_guardrail: Guardrail,
+        output_guardrail: Guardrail,
+        agent_id: Optional[str] = None,
+    ):
         self.input_guardrail = input_guardrail
         self.output_guardrail = output_guardrail
+        self.agent_id = agent_id
 
     def get_input_guardrail(self) -> Guardrail:
         return self.input_guardrail
@@ -36,15 +42,18 @@ class DomeConfig(GuardrailConfig):
     def get_output_guardrail(self) -> Guardrail:
         return self.output_guardrail
 
+    def get_agent_id(self) -> Optional[str]:
+        return self.agent_id
+
 
 def create_dome_config(config: Union[Dict, str]) -> DomeConfig:
     if isinstance(config, str):
-        input_guardrail, output_guardrail = convert_toml_to_guardrails(config)
-        config_object = DomeConfig(input_guardrail, output_guardrail)
+        input_guardrail, output_guardrail, agent_id = convert_toml_to_guardrails(config)
+        config_object = DomeConfig(input_guardrail, output_guardrail, agent_id)
         return config_object
     elif isinstance(config, dict):
-        input_guardrail, output_guardrail = convert_dict_to_guardrails(config)
-        config_object = DomeConfig(input_guardrail, output_guardrail)
+        input_guardrail, output_guardrail, agent_id = convert_dict_to_guardrails(config)
+        config_object = DomeConfig(input_guardrail, output_guardrail, agent_id)
         return config_object
     else:
         raise ValueError(
@@ -89,6 +98,7 @@ class Dome:
         self.client = client
         self.input_guardrail = None  # type: Optional[Guardrail]
         self.output_guardrail = None  # type: Optional[Guardrail]
+        self.agent_id = None  # type: Optional[str]
         if dome_config is not None:
             if isinstance(dome_config, DomeConfig):
                 self._init_from_dome_config(dome_config)
@@ -110,6 +120,7 @@ class Dome:
     def _init_from_dome_config(self, dome_config: DomeConfig):
         self.input_guardrail = dome_config.input_guardrail
         self.output_guardrail = dome_config.output_guardrail
+        self.agent_id = dome_config.agent_id
 
     def get_guardrails(self):
         return [self.input_guardrail, self.output_guardrail]

--- a/vijil_dome/guardrails/config_parser.py
+++ b/vijil_dome/guardrails/config_parser.py
@@ -18,7 +18,7 @@ from vijil_dome.guardrails import Guard, Guardrail
 from vijil_dome.detectors.methods import *  # noqa: F403
 from vijil_dome.detectors import DetectionCategory, DetectionFactory
 import toml
-from typing import Tuple, Dict, Any  # noqa: F401
+from typing import Tuple, Dict, Any, Optional  # noqa: F401
 
 GUARDRAIL_CATEGORY_MAPPING = {
     "security": DetectionCategory.Security,
@@ -148,6 +148,11 @@ def convert_toml_to_guardrail_dict(path_to_toml: str):
         raise ValueError("No [guardrail] in config file!")
 
     raw_config_dict = dict()  # type: Dict[str, Any]
+
+    raw_config_dict["agent_id"] = toml_config_dict.get("guardrail", {}).get(
+        "agent_id", None
+    )
+
     raw_config_dict["input-guards"] = extract_field_from_toml(
         "input", "guards", [], toml_config_dict
     )
@@ -176,13 +181,18 @@ def convert_toml_to_guardrail_dict(path_to_toml: str):
 
 
 # Convert a dictionary into the corresponding guardrails
-def convert_dict_to_guardrails(config_dict: dict) -> Tuple[Guardrail, Guardrail]:
+def convert_dict_to_guardrails(
+    config_dict: dict,
+) -> Tuple[Guardrail, Guardrail, Optional[str]]:
     input_guardrail = create_guardrail("input", config_dict)
     output_guardrail = create_guardrail("output", config_dict)
-    return input_guardrail, output_guardrail
+    agent_id = config_dict.get("agent_id", None)
+    return input_guardrail, output_guardrail, agent_id
 
 
 # convert a toml file into its corresponding guardrails
-def convert_toml_to_guardrails(path_to_toml: str) -> Tuple[Guardrail, Guardrail]:
+def convert_toml_to_guardrails(
+    path_to_toml: str,
+) -> Tuple[Guardrail, Guardrail, Optional[str]]:
     config_dict = convert_toml_to_guardrail_dict(path_to_toml)
     return convert_dict_to_guardrails(config_dict)

--- a/vijil_dome/guardrails/examples/ex_guarded_chat_completions.py
+++ b/vijil_dome/guardrails/examples/ex_guarded_chat_completions.py
@@ -35,7 +35,7 @@ default_guardrail_config = {
     "output-guards": [simple_guard],
 }
 
-input_guardrail, output_guardrail = convert_dict_to_guardrails(default_guardrail_config)
+input_guardrail, output_guardrail, _ = convert_dict_to_guardrails(default_guardrail_config)
 
 
 class SimpleConfig(GuardrailConfig):

--- a/vijil_dome/instrumentation/examples/ex_guardrail.py
+++ b/vijil_dome/instrumentation/examples/ex_guardrail.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     logger.setLevel(logging.INFO)
 
     guardrail_config = create_example_guardrail_config()
-    input_guardrail, output_guardrail = convert_dict_to_guardrails(guardrail_config)
+    input_guardrail, output_guardrail, _ = convert_dict_to_guardrails(guardrail_config)
 
     # Add instrumentation to the input guardrail
 

--- a/vijil_dome/tests/sample_configs/no_id.toml
+++ b/vijil_dome/tests/sample_configs/no_id.toml
@@ -1,0 +1,27 @@
+[guardrail]
+input-guards = ["prompt-injection", "input-toxicity"]  # User Defined Names
+output-guards = ["output-toxicity"]  # User Defined Names
+input-early-exit = false # This setting runs both input guards, even if one catches the prompt
+input-run-parallel = true
+
+[prompt-injection] # matches to UD names
+type="security"
+early-exit = false
+run-parallel = true
+methods = ["security-llm"]
+
+[prompt-injection.security-llm]
+model_name = "gpt-4o-mini"
+
+[input-toxicity] # matches to UD names
+type="moderation"
+methods = ["moderation-prompt-engineering"]
+
+[input-toxicity.moderation-prompt-engineering]
+model_name = "gpt-4o-mini"
+
+[output-toxicity] # matches to UD names
+type="moderation"
+early-exit = false
+run-parallel = true
+methods = ["moderation-flashtext",]

--- a/vijil_dome/tests/sample_configs/with_id.toml
+++ b/vijil_dome/tests/sample_configs/with_id.toml
@@ -1,0 +1,28 @@
+[guardrail]
+input-guards = ["prompt-injection", "input-toxicity"]  # User Defined Names
+output-guards = ["output-toxicity"]  # User Defined Names
+input-early-exit = false # This setting runs both input guards, even if one catches the prompt
+input-run-parallel = true
+agent_id = "sample-agent-001"
+
+[prompt-injection] # matches to UD names
+type="security"
+early-exit = false
+run-parallel = true
+methods = ["security-llm"]
+
+[prompt-injection.security-llm]
+model_name = "gpt-4o-mini"
+
+[input-toxicity] # matches to UD names
+type="moderation"
+methods = ["moderation-prompt-engineering"]
+
+[input-toxicity.moderation-prompt-engineering]
+model_name = "gpt-4o-mini"
+
+[output-toxicity] # matches to UD names
+type="moderation"
+early-exit = false
+run-parallel = true
+methods = ["moderation-flashtext",]

--- a/vijil_dome/tests/test_dome_obj.py
+++ b/vijil_dome/tests/test_dome_obj.py
@@ -152,11 +152,26 @@ async def test_toml_config():
         output_guard_set.add(guard_name)
     assert output_guard_set == {"output-toxicity"}
 
-    assert dome.input_guardrail.run_in_parallel == True
-    assert dome.input_guardrail.early_exit == False
+    assert dome.input_guardrail.run_in_parallel
+    assert not dome.input_guardrail.early_exit
 
     assert dome.agent_id is None
 
     with_id_toml_path = os.path.join(dir_path, "sample_configs", "with_id.toml")
     dome = Dome(dome_config=with_id_toml_path)
     assert dome.agent_id == "sample-agent-001"
+
+    input_guard_set = set()
+    for guard in dome.input_guardrail.guard_list:
+        guard_name = guard.guard_name
+        input_guard_set.add(guard_name)
+
+    assert input_guard_set == {"prompt-injection", "input-toxicity"}
+    output_guard_set = set()
+    for guard in dome.output_guardrail.guard_list:
+        guard_name = guard.guard_name
+        output_guard_set.add(guard_name)
+    assert output_guard_set == {"output-toxicity"}
+
+    assert dome.input_guardrail.run_in_parallel
+    assert not dome.input_guardrail.early_exit

--- a/vijil_dome/tests/test_dome_obj.py
+++ b/vijil_dome/tests/test_dome_obj.py
@@ -15,42 +15,26 @@
 # vijil and vijil-dome are trademarks owned by Vijil Inc.
 
 import pytest
-
+import os
 from vijil_dome import Dome, create_dome_config
 
 TEST_CONFIG = {
-    "input-guards": [
-        "prompt-injection",
-        "input-toxicity"
-    ],
-    "output-guards": [
-        "output-toxicity"
-    ],
+    "input-guards": ["prompt-injection", "input-toxicity"],
+    "output-guards": ["output-toxicity"],
     "input-early-exit": False,
     "prompt-injection": {
         "type": "security",
         "early-exit": False,
-        "methods": [
-            "prompt-injection-deberta-v3-base",
-            "security-llm"
-        ],
-        "security-llm": {
-            "model_name": "gpt-4o"
-        }
+        "methods": ["prompt-injection-deberta-v3-base", "security-llm"],
+        "security-llm": {"model_name": "gpt-4o"},
     },
-    "input-toxicity": {
-        "type": "moderation",
-        "methods": [
-            "moderations-oai-api"
-        ]
-    },
+    "input-toxicity": {"type": "moderation", "methods": ["moderations-oai-api"]},
     "output-toxicity": {
         "type": "moderation",
-        "methods": [
-            "moderation-prompt-engineering"
-        ]
-    }
+        "methods": ["moderation-prompt-engineering"],
+    },
 }
+
 
 @pytest.mark.asyncio
 async def test_dome_config():
@@ -62,6 +46,7 @@ async def test_dome_config():
     assert dome.output_guardrail.early_exit
     assert not dome.input_guardrail.run_in_parallel
     assert not dome.output_guardrail.run_in_parallel
+    assert dome.agent_id is None
 
 
 def test_input_detection_safe():
@@ -94,6 +79,7 @@ def test_output_detection_unsafe():
 
     scan = dome.guard_output(unsafe_output)
     assert not scan.is_safe()
+
 
 @pytest.mark.asyncio
 async def test_async_input_detection_safe():
@@ -138,3 +124,39 @@ async def test_async_default_config():
 
     scan = await dome.async_guard_input(safe_input)
     assert scan.is_safe()
+
+
+@pytest.mark.asyncio
+async def test_async_config_agent_id():
+    config_with_agent_id = TEST_CONFIG.copy()
+    config_with_agent_id["agent_id"] = "test-agent-123"
+    dome = Dome(dome_config=create_dome_config(config_with_agent_id))
+    assert dome.agent_id == "test-agent-123"
+
+
+@pytest.mark.asyncio
+async def test_toml_config():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    toml_path = os.path.join(dir_path, "sample_configs", "no_id.toml")
+    dome = Dome(dome_config=toml_path)
+
+    input_guard_set = set()
+    for guard in dome.input_guardrail.guard_list:
+        guard_name = guard.guard_name
+        input_guard_set.add(guard_name)
+
+    assert input_guard_set == {"prompt-injection", "input-toxicity"}
+    output_guard_set = set()
+    for guard in dome.output_guardrail.guard_list:
+        guard_name = guard.guard_name
+        output_guard_set.add(guard_name)
+    assert output_guard_set == {"output-toxicity"}
+
+    assert dome.input_guardrail.run_in_parallel == True
+    assert dome.input_guardrail.early_exit == False
+
+    assert dome.agent_id is None
+
+    with_id_toml_path = os.path.join(dir_path, "sample_configs", "with_id.toml")
+    dome = Dome(dome_config=with_id_toml_path)
+    assert dome.agent_id == "sample-agent-001"


### PR DESCRIPTION
Adds an optional agent ID parameter to the configs (both dict and toml based) that can be used for resource instrumentation. Also includes additional tests for config validation and loading 