### PR TITLE
Load configs directly from vijil evaluate

### DIFF
--- a/vijil_dome/Dome.py
+++ b/vijil_dome/Dome.py
@@ -19,6 +19,7 @@ from vijil_dome.guardrails.config_parser import (
     convert_dict_to_guardrails,
     convert_toml_to_guardrails,
 )
+from vijil_dome.integrations.vijil.evaluate import get_config_from_vijil_agent
 from openai import OpenAI
 from typing import Union, Dict, Optional, Callable
 from .defaults import get_default_config
@@ -116,6 +117,18 @@ class Dome:
         config: Union[Dict, str], client: Optional[OpenAI] = None
     ) -> "Dome":
         return Dome(dome_config=config, client=client)
+
+    @staticmethod
+    def create_from_vijil_agent(
+        agent_id: str,
+        api_key: str,
+        base_url: Optional[str] = None,
+        client: Optional[OpenAI] = None,
+    ) -> "Dome":
+        config_dict = get_config_from_vijil_agent(api_key, agent_id, base_url)
+        if config_dict is None:
+            raise ValueError(f"No Dome configuration found for agent ID {agent_id}")
+        return Dome(dome_config=config_dict, client=client)
 
     def _init_from_dome_config(self, dome_config: DomeConfig):
         self.input_guardrail = dome_config.input_guardrail

--- a/vijil_dome/Dome.py
+++ b/vijil_dome/Dome.py
@@ -84,7 +84,7 @@ class ScanResult(BaseModel):
             "exec_time": self.exec_time,
             "response": self.response_string,
         }
-        return result_dict
+        return str(result_dict)
 
     def __repr__(self):
         return self.__str__()

--- a/vijil_dome/integrations/vijil/evaluate.py
+++ b/vijil_dome/integrations/vijil/evaluate.py
@@ -1,0 +1,48 @@
+"""
+Integrations with Vijil Evaluate
+"""
+
+import httpx
+from typing import Optional
+
+VIJIL_API_BASE_URL = "https://evaluate-api.vijil.ai/v1"
+
+
+def get_config_from_vijil_agent(
+    api_token: str, agent_id: str, base_url: Optional[str] = None
+) -> Optional[dict]:
+    """
+    Fetch the Dome configuration from Vijil Evaluate using the provided API token and agent ID.
+
+    Args:
+        api_token (str): The API token for authentication.
+        agent_id (str): The ID of the agent whose configuration is to be fetched.
+
+    Returns:
+        dict: The Dome configuration as a dictionary.
+
+    Raises:
+        Exception: If the API call fails or returns an error.
+    """
+    headers = {
+        "Authorization": f"Bearer {api_token}",
+        "Content-Type": "application/json",
+    }
+    base_url = base_url or VIJIL_API_BASE_URL
+    url = f"{base_url}/agent-configurations/{agent_id}/dome-configs"
+
+    try:
+        response = httpx.get(url, headers=headers)
+        response.raise_for_status()
+        response_json = response.json()
+        dome_configs = response_json.get("dome_configs")
+        if dome_configs is None:
+            raise Exception("Dome configuration not found in the response.")
+        else:
+            if len(dome_configs) == 0:
+                return None
+            else:
+                config = dome_configs[0].get("config_body", None)
+                return config
+    except httpx.HTTPError as e:
+        raise Exception(f"Failed to fetch Dome config: {e}")


### PR DESCRIPTION
Enables an instance of Dome to be created using an agent ID on Vijil evaluate. 

Example
```
dome = Dome.create_from_vijil_agent(
    agent_id=AGENT_ID,
    api_key=API_KEY,
)
```