### PR TITLE
Recommend dome config from an evaluation

### DIFF
--- a/vijil_dome/Dome.py
+++ b/vijil_dome/Dome.py
@@ -19,7 +19,10 @@ from vijil_dome.guardrails.config_parser import (
     convert_dict_to_guardrails,
     convert_toml_to_guardrails,
 )
-from vijil_dome.integrations.vijil.evaluate import get_config_from_vijil_agent
+from vijil_dome.integrations.vijil.evaluate import (
+    get_config_from_vijil_agent,
+    get_config_from_vijil_evaluation,
+)
 from openai import OpenAI
 from typing import Union, Dict, Optional, Callable
 from .defaults import get_default_config
@@ -126,8 +129,23 @@ class Dome:
         client: Optional[OpenAI] = None,
     ) -> "Dome":
         config_dict = get_config_from_vijil_agent(api_key, agent_id, base_url)
+        print(config_dict)
         if config_dict is None:
             raise ValueError(f"No Dome configuration found for agent ID {agent_id}")
+        return Dome(dome_config=config_dict, client=client)
+
+    @staticmethod
+    def create_from_vijil_evaluation(
+        evaluation_id: str,
+        api_key: str,
+        base_url: Optional[str] = None,
+        client: Optional[OpenAI] = None,
+    ) -> "Dome":
+        config_dict = get_config_from_vijil_evaluation(api_key, evaluation_id, base_url)
+        if config_dict is None:
+            raise ValueError(
+                f"No Dome configuration recommendation could be generated for evaluation ID {evaluation_id}"
+            )
         return Dome(dome_config=config_dict, client=client)
 
     def _init_from_dome_config(self, dome_config: DomeConfig):

--- a/vijil_dome/integrations/vijil/evaluate.py
+++ b/vijil_dome/integrations/vijil/evaluate.py
@@ -46,3 +46,40 @@ def get_config_from_vijil_agent(
                 return config
     except httpx.HTTPError as e:
         raise Exception(f"Failed to fetch Dome config: {e}")
+
+
+def get_config_from_vijil_evaluation(
+    api_token: str, evaluation_id: str, base_url: Optional[str] = None
+) -> Optional[dict]:
+    """
+    Fetch the Dome configuration from a specific evaluation in Vijil Evaluate using the provided API token and evaluation ID.
+
+    Args:
+        api_token (str): The API token for authentication.
+        evaluation_id (str): The ID of the evaluation whose configuration is to be fetched.
+
+    Returns:
+        dict: The Dome configuration as a dictionary.
+
+    Raises:
+        Exception: If the API call fails or returns an error.
+    """
+    headers = {
+        "Authorization": f"Bearer {api_token}",
+        "Content-Type": "application/json",
+    }
+    base_url = base_url or VIJIL_API_BASE_URL
+    url = f"{base_url}/recommend-dome-config"
+
+    payload = {"evaluation_id": evaluation_id}
+
+    try:
+        response = httpx.post(url, headers=headers, json=payload)
+        response.raise_for_status()
+        dome_config = response.json()
+        if dome_config is None:
+            raise Exception("Dome configuration not found in the response.")
+        else:
+            return dome_config
+    except httpx.HTTPError as e:
+        raise Exception(f"Failed to fetch Dome config: {e}")


### PR DESCRIPTION
Adds the ability to get Dome config recommendations from a standalone URL - useful for ephemeral agents that have been evaluated but not registered on Vijil Evaluate. 