### PR TITLE
feat(telemetry): Darwin-compatible instrumentation for evolution workflow [DOME-63]

### DIFF
--- a/docs/plans/2026-02-04-darwin-telemetry-integration-design.md
+++ b/docs/plans/2026-02-04-darwin-telemetry-integration-design.md
@@ -1,0 +1,353 @@
+# Darwin-Compatible Telemetry Integration Design
+
+> **For Claude:** This is a design document for enhancing Dome's telemetry to integrate with Darwin evolution. Use `superpowers:writing-plans` to create implementation tasks.
+
+**Date:** 2026-02-04
+**Status:** Draft
+**Authors:** Claude (analysis and design)
+
+---
+
+## Executive Summary
+
+Darwin's evolution workflow requires Dome detection telemetry to trigger mutations. Currently, there's a **critical schema mismatch** between Dome's telemetry output and Darwin's expected input format. This design proposes minimal changes to Dome's instrumentation to enable seamless integration.
+
+---
+
+## Problem Statement
+
+### Current State
+
+**Dome emits** (via OpenTelemetry):
+
+| Component | What Dome Sends | Example |
+|-----------|-----------------|---------|
+| **Metric name** | `{guardrail_name}-flagged_total` | `input-guardrail-flagged_total` |
+| **Metric attributes** | `agent.id` only | `{"agent.id": "agent-123"}` |
+| **Span attributes** | `function.result` (string dump) | `"{'flagged': True, 'score': 0.85, ...}"` |
+| **Service name** | Not explicitly set | (inherits from OTEL config) |
+
+**Darwin expects** (TelemetryDetectionAdapter):
+
+| Component | What Darwin Queries | Example |
+|-----------|---------------------|---------|
+| **Metric name** | `dome-flagged_total` | Fixed prefix |
+| **Metric attributes** | `agent_configuration_id`, `team_id` | Multi-tenant filtering |
+| **Span attributes** | `detection.score`, `detection.label`, `detection.method` | Structured typed attributes |
+| **Service name filter** | `service.name="service-dome"` | Service-based filtering |
+
+### Impact
+
+- **Metrics queries fail**: Metric naming mismatch
+- **Trace parsing fails**: Missing structured attributes
+- **Multi-tenant filtering fails**: Missing `team_id`
+- **Detection classification fails**: Missing `detection.method`
+
+---
+
+## Proposed Solution
+
+### Option A: Darwin-Aware Tracing Decorator (Recommended)
+
+Add a new decorator that emits Darwin-compatible span attributes alongside the existing generic attributes.
+
+**New file: `vijil_dome/integrations/vijil/telemetry.py`**
+
+```python
+"""Darwin-compatible telemetry instrumentation for Dome.
+
+When Dome runs in the Vijil platform context, this module provides
+enhanced instrumentation that emits span attributes Darwin can parse.
+"""
+
+from functools import wraps
+from inspect import iscoroutinefunction
+from typing import Callable, Optional
+
+from opentelemetry.sdk.trace import Tracer, Span
+from pydantic import BaseModel
+
+from vijil_dome.guardrails import GuardrailResult, GuardResult
+
+
+def _set_darwin_span_attributes(
+    span: Span,
+    result: GuardrailResult | GuardResult,
+    agent_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+) -> None:
+    """Set Darwin-compatible span attributes.
+
+    Args:
+        span: The current OTEL span
+        result: Guardrail or Guard scan result
+        agent_id: Agent configuration ID (from kwargs)
+        team_id: Team ID for multi-tenant filtering
+    """
+    # Team and agent context
+    if team_id:
+        span.set_attribute("team.id", team_id)
+    if agent_id:
+        span.set_attribute("agent.id", agent_id)
+
+    # Detection attributes Darwin expects
+    span.set_attribute("detection.label", "flagged" if result.flagged else "clean")
+
+    # Extract score - prefer max_score, fallback to first detection score
+    score = 0.0
+    if hasattr(result, "trace") and result.trace:
+        # GuardrailResult has trace dict with guard results
+        for guard_name, guard_result in result.trace.items():
+            if isinstance(guard_result, dict) and guard_result.get("triggered"):
+                for det_name, det_result in guard_result.get("detections", {}).items():
+                    if isinstance(det_result, dict):
+                        score = max(score, det_result.get("score", 0.0))
+    span.set_attribute("detection.score", score)
+
+    # Extract method from first triggered guard
+    method = "unknown"
+    if hasattr(result, "trace") and result.trace:
+        for guard_name, guard_result in result.trace.items():
+            if isinstance(guard_result, dict) and guard_result.get("triggered"):
+                method = guard_name
+                break
+    span.set_attribute("detection.method", method)
+
+
+def darwin_trace(tracer: Tracer, name: str):
+    """Decorator for Darwin-compatible tracing.
+
+    Wraps scan functions to emit both generic and Darwin-specific
+    span attributes for integration with the evolution workflow.
+
+    Usage:
+        @darwin_trace(tracer, "input-guardrail.scan")
+        def scan(self, input_text: str, agent_id: str = None, team_id: str = None):
+            ...
+    """
+    def decorator(func: Callable):
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            with tracer.start_as_current_span(name) as span:
+                # Generic attributes (existing behavior)
+                span.set_attribute("function.args", str(args))
+                span.set_attribute("function.kwargs", str(kwargs))
+
+                result = func(*args, **kwargs)
+
+                # Generic result attribute
+                if isinstance(result, BaseModel):
+                    span.set_attribute("function.result", str(result.model_dump()))
+                else:
+                    span.set_attribute("function.result", str(result))
+
+                # Darwin-specific attributes
+                if isinstance(result, (GuardrailResult, GuardResult)):
+                    _set_darwin_span_attributes(
+                        span,
+                        result,
+                        agent_id=kwargs.get("agent_id"),
+                        team_id=kwargs.get("team_id"),
+                    )
+
+                return result
+
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            with tracer.start_as_current_span(name) as span:
+                span.set_attribute("function.args", str(args))
+                span.set_attribute("function.kwargs", str(kwargs))
+
+                result = await func(*args, **kwargs)
+
+                if isinstance(result, BaseModel):
+                    span.set_attribute("function.result", str(result.model_dump()))
+                else:
+                    span.set_attribute("function.result", str(result))
+
+                if isinstance(result, (GuardrailResult, GuardResult)):
+                    _set_darwin_span_attributes(
+                        span,
+                        result,
+                        agent_id=kwargs.get("agent_id"),
+                        team_id=kwargs.get("team_id"),
+                    )
+
+                return result
+
+        return async_wrapper if iscoroutinefunction(func) else sync_wrapper
+    return decorator
+```
+
+### Metric Naming Enhancement
+
+Add a consistent metric prefix for Darwin compatibility:
+
+**Update: `vijil_dome/guardrails/instrumentation/metrics.py`**
+
+```python
+# Add constant for Darwin-compatible metric prefix
+DARWIN_METRIC_PREFIX = "dome"
+
+def _create_request_flagged_counter(name: str, meter: Meter, darwin_compatible: bool = False):
+    """Create flagged counter with optional Darwin-compatible naming."""
+    metric_name = f"{DARWIN_METRIC_PREFIX}-flagged_total" if darwin_compatible else f"{name}-flagged_total"
+    return meter.create_counter(
+        metric_name,
+        description=f"Number of requests to {name} that are flagged",
+    )
+```
+
+### Integration Function
+
+Provide a single function to set up Darwin-compatible instrumentation:
+
+```python
+def instrument_for_darwin(
+    guardrail: Guardrail,
+    tracer: Tracer,
+    meter: Meter,
+    guardrail_name: Optional[str] = None,
+) -> None:
+    """Set up Darwin-compatible instrumentation for a guardrail.
+
+    This function configures both tracing and metrics with Darwin-compatible
+    attributes and naming conventions.
+
+    Args:
+        guardrail: The guardrail to instrument
+        tracer: OTEL tracer for span creation
+        meter: OTEL meter for metrics
+        guardrail_name: Optional custom name (default: guardrail.level-guardrail)
+
+    Example:
+        from vijil_dome.integrations.vijil.telemetry import instrument_for_darwin
+
+        dome = Dome(config)
+        tracer = trace.get_tracer("service-dome")
+        meter = metrics.get_meter("service-dome")
+
+        instrument_for_darwin(dome.input_guardrail, tracer, meter)
+    """
+    # Implementation uses darwin_trace decorator and Darwin metric naming
+    ...
+```
+
+---
+
+## Integration Points
+
+### Console Service (service_dome)
+
+When running Dome in the Console context, use Darwin-compatible instrumentation:
+
+```python
+# In vijil-console/src/service_dome/main.py
+from vijil_dome import Dome
+from vijil_dome.integrations.vijil.telemetry import instrument_for_darwin
+from opentelemetry import trace, metrics
+
+dome = Dome(config)
+tracer = trace.get_tracer("service-dome")  # Darwin expects this service name
+meter = metrics.get_meter("service-dome")
+
+instrument_for_darwin(dome.input_guardrail, tracer, meter)
+instrument_for_darwin(dome.output_guardrail, tracer, meter)
+```
+
+### Standalone Dome Usage
+
+For standalone Dome usage (not in Vijil platform), the existing instrumentation remains unchanged.
+
+---
+
+## Attribute Reference
+
+### Span Attributes Set by Darwin-Compatible Tracing
+
+| Attribute | Type | Description | Example |
+|-----------|------|-------------|---------|
+| `team.id` | string | Team ID for multi-tenant filtering | `"7295f905-194b-42a8-95e2-..."` |
+| `agent.id` | string | Agent configuration ID | `"agent-cs-helpdesk-v2"` |
+| `detection.label` | string | "flagged" or "clean" | `"flagged"` |
+| `detection.score` | double | Max detection confidence (0.0-1.0) | `0.92` |
+| `detection.method` | string | Guard/detector that triggered | `"prompt-injection"` |
+| `function.args` | string | (Existing) String dump of args | `"('input text',)"` |
+| `function.kwargs` | string | (Existing) String dump of kwargs | `"{'agent_id': '...'}"` |
+| `function.result` | string | (Existing) String dump of result | `"{'flagged': True, ...}"` |
+
+### Metrics Emitted with Darwin-Compatible Naming
+
+| Metric | Type | Attributes | Description |
+|--------|------|------------|-------------|
+| `dome-flagged_total` | Counter | `agent.id`, `team.id` | Total flagged detections |
+| `dome-requests_total` | Counter | `agent.id`, `team.id` | Total scan requests |
+| `dome-latency_seconds` | Histogram | `agent.id`, `team.id` | Scan latency |
+
+---
+
+## Migration Path
+
+### Phase 1: Add Darwin-Compatible Module (Non-Breaking)
+
+1. Add `vijil_dome/integrations/vijil/telemetry.py` with Darwin tracing
+2. Add `instrument_for_darwin()` convenience function
+3. No changes to existing `auto_trace` or metrics
+
+### Phase 2: Console Integration
+
+1. Update `service_dome` in vijil-console to use `instrument_for_darwin()`
+2. Set OTEL service name to `service-dome`
+3. Verify Darwin can query detections via Tempo/Mimir
+
+### Phase 3: TelemetryDetectionAdapter Alignment
+
+1. Update Darwin's adapter to handle both old and new formats
+2. Prefer structured attributes, fallback to string parsing
+3. Document expected attribute schema
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+```python
+def test_darwin_span_attributes():
+    """Darwin-compatible attributes are set on spans."""
+    result = GuardrailResult(flagged=True, trace={...})
+    span = MockSpan()
+
+    _set_darwin_span_attributes(span, result, agent_id="agent-1", team_id="team-1")
+
+    assert span.attributes["team.id"] == "team-1"
+    assert span.attributes["detection.label"] == "flagged"
+    assert span.attributes["detection.score"] > 0
+    assert span.attributes["detection.method"] != "unknown"
+```
+
+### Integration Tests
+
+1. Deploy Dome with Darwin instrumentation
+2. Generate detections via test prompts
+3. Query Tempo for traces with Darwin attributes
+4. Query Mimir for `dome-flagged_total` metric
+5. Verify Darwin can create mutation proposals from detections
+
+---
+
+## Open Questions
+
+1. **Backward compatibility**: Should Darwin adapter support both formats during migration?
+2. **Team ID propagation**: How is `team_id` passed through the request chain?
+3. **Metric aggregation**: Should Darwin query by guardrail name or use aggregated `dome-*` metrics?
+
+---
+
+## Next Steps
+
+1. [ ] Implement `vijil_dome/integrations/vijil/telemetry.py`
+2. [ ] Add unit tests for Darwin attributes
+3. [ ] Update service_dome to use Darwin instrumentation
+4. [ ] Update Darwin's TelemetryDetectionAdapter for new format
+5. [ ] End-to-end test: Dome detection → Darwin mutation proposal

--- a/vijil_dome/integrations/vijil/__init__.py
+++ b/vijil_dome/integrations/vijil/__init__.py
@@ -1,0 +1,42 @@
+"""Vijil platform integrations for Dome.
+
+This module provides integrations with the Vijil platform:
+- evaluate: Fetch Dome configs from Vijil Evaluate API
+- telemetry: Darwin-compatible OpenTelemetry instrumentation
+
+Example:
+    # Fetch config from Vijil Evaluate
+    from vijil_dome.integrations.vijil.evaluate import get_config_from_vijil_agent
+    config = get_config_from_vijil_agent(api_token, agent_id)
+
+    # Set up Darwin-compatible telemetry
+    from vijil_dome.integrations.vijil.telemetry import instrument_for_darwin
+    instrument_for_darwin(dome.input_guardrail, tracer, meter)
+"""
+
+from vijil_dome.integrations.vijil.evaluate import (
+    get_config_from_vijil_agent,
+    get_config_from_vijil_evaluation,
+)
+
+from vijil_dome.integrations.vijil.telemetry import (
+    darwin_trace,
+    instrument_for_darwin,
+    create_darwin_flagged_counter,
+    create_darwin_requests_counter,
+    create_darwin_latency_histogram,
+    DARWIN_METRIC_PREFIX,
+)
+
+__all__ = [
+    # Evaluate integration
+    "get_config_from_vijil_agent",
+    "get_config_from_vijil_evaluation",
+    # Darwin telemetry
+    "darwin_trace",
+    "instrument_for_darwin",
+    "create_darwin_flagged_counter",
+    "create_darwin_requests_counter",
+    "create_darwin_latency_histogram",
+    "DARWIN_METRIC_PREFIX",
+]

--- a/vijil_dome/integrations/vijil/telemetry.py
+++ b/vijil_dome/integrations/vijil/telemetry.py
@@ -1,0 +1,376 @@
+"""Darwin-compatible telemetry instrumentation for Dome.
+
+When Dome runs in the Vijil platform context, this module provides
+enhanced instrumentation that emits span attributes Darwin can parse
+for triggering evolution mutations.
+
+Key differences from generic auto_trace:
+- Typed span attributes (detection.score as float, not string dump)
+- Team context (team.id for multi-tenant filtering)
+- Standardized metric naming (dome-flagged_total vs {guardrail}-flagged_total)
+
+Usage:
+    from vijil_dome.integrations.vijil.telemetry import darwin_trace, instrument_for_darwin
+    from opentelemetry import trace, metrics
+
+    tracer = trace.get_tracer("service-dome")
+    meter = metrics.get_meter("service-dome")
+
+    # Option 1: Use decorator directly
+    @darwin_trace(tracer, "input-guardrail.scan")
+    def my_scan_function(...):
+        ...
+
+    # Option 2: Instrument existing guardrail
+    instrument_for_darwin(dome.input_guardrail, tracer, meter)
+"""
+
+from functools import wraps
+from inspect import iscoroutinefunction
+from typing import Callable, Optional, Any, Union, TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace import Tracer, Span
+    from opentelemetry.sdk.metrics import Meter
+
+from vijil_dome.guardrails import GuardrailResult, GuardResult
+
+
+# Darwin-compatible metric prefix
+DARWIN_METRIC_PREFIX = "dome"
+
+
+def _extract_detection_score(result: Union[GuardrailResult, GuardResult]) -> float:
+    """Extract the maximum detection score from a guard/guardrail result.
+
+    For GuardrailResult: Walks through guard_exec_details to find triggered
+    detections and returns the highest score.
+
+    For GuardResult: Walks through details to find the highest detection score.
+
+    Args:
+        result: The scan result from a guard or guardrail.
+
+    Returns:
+        The maximum detection score (0.0-1.0), or 0.0 if no detections.
+    """
+    max_score = 0.0
+
+    if isinstance(result, GuardrailResult):
+        # GuardrailResult.guard_exec_details: Dict[str, GuardResult]
+        for guard_name, guard_result in result.guard_exec_details.items():
+            if guard_result.triggered:
+                # GuardResult.details: Dict[str, DetectionTimingResult]
+                for detector_name, detection in guard_result.details.items():
+                    if hasattr(detection, "result") and isinstance(detection.result, dict):
+                        score = detection.result.get("score", 0.0)
+                        if isinstance(score, (int, float)):
+                            max_score = max(max_score, float(score))
+
+    elif isinstance(result, GuardResult):
+        # GuardResult.details: Dict[str, DetectionTimingResult]
+        for detector_name, detection in result.details.items():
+            if hasattr(detection, "result") and isinstance(detection.result, dict):
+                score = detection.result.get("score", 0.0)
+                if isinstance(score, (int, float)):
+                    max_score = max(max_score, float(score))
+
+    return max_score
+
+
+def _extract_detection_method(result: Union[GuardrailResult, GuardResult]) -> str:
+    """Extract the name of the first triggered guard/detector.
+
+    Darwin uses this to understand which detection method flagged the input,
+    enabling targeted mutations for specific vulnerability types.
+
+    Args:
+        result: The scan result from a guard or guardrail.
+
+    Returns:
+        The name of the triggered guard/detector, or "unknown" if none.
+    """
+    if isinstance(result, GuardrailResult):
+        for guard_name, guard_result in result.guard_exec_details.items():
+            if guard_result.triggered:
+                return guard_name
+
+    elif isinstance(result, GuardResult):
+        if result.triggered:
+            for detector_name, detection in result.details.items():
+                if hasattr(detection, "hit") and detection.hit:
+                    return detector_name
+
+    return "unknown"
+
+
+def _set_darwin_span_attributes(
+    span: "Span",
+    result: Union[GuardrailResult, GuardResult],
+    agent_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+) -> None:
+    """Set Darwin-compatible span attributes on the current span.
+
+    These attributes enable Darwin's TelemetryDetectionAdapter to query
+    detections from Tempo traces and create mutation proposals.
+
+    Args:
+        span: The current OTEL span.
+        result: Guardrail or Guard scan result.
+        agent_id: Agent configuration ID (for agent-specific mutations).
+        team_id: Team ID for multi-tenant filtering.
+    """
+    # Team and agent context
+    if team_id:
+        span.set_attribute("team.id", team_id)
+    if agent_id:
+        span.set_attribute("agent.id", agent_id)
+
+    # Detection label (Darwin expects "flagged" or "clean")
+    is_flagged = (
+        result.flagged if isinstance(result, GuardrailResult) else result.triggered
+    )
+    span.set_attribute("detection.label", "flagged" if is_flagged else "clean")
+
+    # Detection score (0.0-1.0)
+    score = _extract_detection_score(result)
+    span.set_attribute("detection.score", score)
+
+    # Detection method (which guard/detector triggered)
+    method = _extract_detection_method(result)
+    span.set_attribute("detection.method", method)
+
+
+def darwin_trace(tracer: "Tracer", name: str) -> Callable:
+    """Decorator for Darwin-compatible tracing of scan functions.
+
+    Wraps scan functions to emit both generic (existing behavior) and
+    Darwin-specific (queryable) span attributes for integration with
+    the evolution workflow.
+
+    The wrapped function MUST return a GuardrailResult or GuardResult.
+    Darwin-specific attributes are only set when the return type is correct.
+
+    Usage:
+        @darwin_trace(tracer, "input-guardrail.scan")
+        def scan(self, input_text: str, agent_id: str = None, team_id: str = None):
+            ...
+
+        @darwin_trace(tracer, "output-guardrail.async-scan")
+        async def async_scan(self, output_text: str, **kwargs):
+            ...
+
+    Args:
+        tracer: OTEL tracer instance (from trace.get_tracer("service-dome")).
+        name: Span name (e.g., "input-guardrail.scan").
+
+    Returns:
+        Decorator function.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            with tracer.start_as_current_span(name) as span:
+                # Generic attributes (existing behavior for backward compatibility)
+                span.set_attribute("function.args", str(args))
+                span.set_attribute("function.kwargs", str(kwargs))
+
+                result = func(*args, **kwargs)
+
+                # Generic result attribute (existing behavior)
+                if isinstance(result, BaseModel):
+                    span.set_attribute("function.result", str(result.model_dump()))
+                else:
+                    span.set_attribute("function.result", str(result))
+
+                # Darwin-specific attributes (NEW - enables evolution workflow)
+                if isinstance(result, (GuardrailResult, GuardResult)):
+                    _set_darwin_span_attributes(
+                        span,
+                        result,
+                        agent_id=kwargs.get("agent_id"),
+                        team_id=kwargs.get("team_id"),
+                    )
+
+                return result
+
+        @wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            with tracer.start_as_current_span(name) as span:
+                # Generic attributes (existing behavior)
+                span.set_attribute("function.args", str(args))
+                span.set_attribute("function.kwargs", str(kwargs))
+
+                result = await func(*args, **kwargs)
+
+                # Generic result attribute (existing behavior)
+                if isinstance(result, BaseModel):
+                    span.set_attribute("function.result", str(result.model_dump()))
+                else:
+                    span.set_attribute("function.result", str(result))
+
+                # Darwin-specific attributes (NEW - enables evolution workflow)
+                if isinstance(result, (GuardrailResult, GuardResult)):
+                    _set_darwin_span_attributes(
+                        span,
+                        result,
+                        agent_id=kwargs.get("agent_id"),
+                        team_id=kwargs.get("team_id"),
+                    )
+
+                return result
+
+        return async_wrapper if iscoroutinefunction(func) else sync_wrapper
+
+    return decorator
+
+
+def create_darwin_flagged_counter(meter: "Meter", level: str = "guardrail"):
+    """Create a Darwin-compatible flagged counter metric.
+
+    Uses standardized naming that Darwin's Mimir queries expect:
+    - dome-flagged_total (instead of {guardrail_name}-flagged_total)
+
+    Args:
+        meter: OTEL meter instance.
+        level: Either "guardrail" or "guard" for description context.
+
+    Returns:
+        Counter metric for flagged detections.
+    """
+    return meter.create_counter(
+        f"{DARWIN_METRIC_PREFIX}-flagged_total",
+        description=f"Number of requests to {level} that are flagged (Darwin-compatible)",
+    )
+
+
+def create_darwin_requests_counter(meter: "Meter", level: str = "guardrail"):
+    """Create a Darwin-compatible requests counter metric.
+
+    Args:
+        meter: OTEL meter instance.
+        level: Either "guardrail" or "guard" for description context.
+
+    Returns:
+        Counter metric for total requests.
+    """
+    return meter.create_counter(
+        f"{DARWIN_METRIC_PREFIX}-requests_total",
+        description=f"Total requests to {level} (Darwin-compatible)",
+    )
+
+
+def create_darwin_latency_histogram(meter: "Meter", level: str = "guardrail"):
+    """Create a Darwin-compatible latency histogram metric.
+
+    Args:
+        meter: OTEL meter instance.
+        level: Either "guardrail" or "guard" for description context.
+
+    Returns:
+        Histogram metric for scan latency.
+    """
+    return meter.create_histogram(
+        f"{DARWIN_METRIC_PREFIX}-latency_seconds",
+        description=f"Scan latency for {level} (Darwin-compatible)",
+        unit="s",
+    )
+
+
+def instrument_for_darwin(
+    guardrail: Any,
+    tracer: "Tracer",
+    meter: "Meter",
+    guardrail_name: Optional[str] = None,
+) -> None:
+    """Set up Darwin-compatible instrumentation for a guardrail.
+
+    This function patches a guardrail's scan methods to emit Darwin-compatible
+    telemetry. It creates metrics with standardized naming and wraps the scan
+    functions with darwin_trace.
+
+    Note: This modifies the guardrail in-place. Call once at application startup.
+
+    Args:
+        guardrail: The Guardrail instance to instrument.
+        tracer: OTEL tracer for span creation.
+        meter: OTEL meter for metrics.
+        guardrail_name: Optional custom name (default: guardrail.level-guardrail).
+
+    Example:
+        from vijil_dome import Dome
+        from vijil_dome.integrations.vijil.telemetry import instrument_for_darwin
+        from opentelemetry import trace, metrics
+
+        dome = Dome(config)
+        tracer = trace.get_tracer("service-dome")
+        meter = metrics.get_meter("service-dome")
+
+        instrument_for_darwin(dome.input_guardrail, tracer, meter)
+        instrument_for_darwin(dome.output_guardrail, tracer, meter)
+    """
+    from vijil_dome.guardrails import Guardrail
+
+    if not isinstance(guardrail, Guardrail):
+        raise TypeError(f"Expected Guardrail, got {type(guardrail).__name__}")
+
+    name = guardrail_name or f"{guardrail.level}-guardrail"
+
+    # Create Darwin-compatible metrics
+    flagged_counter = create_darwin_flagged_counter(meter, name)
+    requests_counter = create_darwin_requests_counter(meter, name)
+    latency_histogram = create_darwin_latency_histogram(meter, name)
+
+    # Store original methods
+    original_scan = guardrail.scan
+    original_async_scan = guardrail.async_scan
+
+    # Wrap sync scan with Darwin instrumentation
+    @darwin_trace(tracer, f"{name}.scan")
+    def instrumented_scan(
+        query_string: str, agent_id: Optional[str] = None, team_id: Optional[str] = None
+    ) -> GuardrailResult:
+        result = original_scan(query_string, agent_id=agent_id)
+
+        # Record metrics with Darwin-compatible attributes
+        labels = {}
+        if agent_id:
+            labels["agent.id"] = agent_id
+        if team_id:
+            labels["team.id"] = team_id
+
+        requests_counter.add(1, labels)
+        latency_histogram.record(result.exec_time, labels)
+        if result.flagged:
+            flagged_counter.add(1, labels)
+
+        return result
+
+    # Wrap async scan with Darwin instrumentation
+    @darwin_trace(tracer, f"{name}.async-scan")
+    async def instrumented_async_scan(
+        query_string: str, agent_id: Optional[str] = None, team_id: Optional[str] = None
+    ) -> GuardrailResult:
+        result = await original_async_scan(query_string, agent_id=agent_id)
+
+        # Record metrics with Darwin-compatible attributes
+        labels = {}
+        if agent_id:
+            labels["agent.id"] = agent_id
+        if team_id:
+            labels["team.id"] = team_id
+
+        requests_counter.add(1, labels)
+        latency_histogram.record(result.exec_time, labels)
+        if result.flagged:
+            flagged_counter.add(1, labels)
+
+        return result
+
+    # Replace methods with instrumented versions
+    guardrail.scan = instrumented_scan
+    guardrail.async_scan = instrumented_async_scan

--- a/vijil_dome/tests/integrations/__init__.py
+++ b/vijil_dome/tests/integrations/__init__.py
@@ -1,0 +1,1 @@
+# Integration tests for Vijil platform integrations

--- a/vijil_dome/tests/integrations/test_darwin_telemetry.py
+++ b/vijil_dome/tests/integrations/test_darwin_telemetry.py
@@ -1,0 +1,330 @@
+# Copyright 2025 Vijil, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# vijil and vijil-dome are trademarks owned by Vijil Inc.
+
+"""Tests for Darwin-compatible telemetry instrumentation.
+
+These tests verify that the Darwin telemetry module emits the correct
+span attributes and metrics that Darwin's TelemetryDetectionAdapter
+can query to trigger evolution mutations.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+
+from vijil_dome.guardrails import GuardrailResult, GuardResult
+from vijil_dome.detectors import DetectionTimingResult
+from vijil_dome.integrations.vijil.telemetry import (
+    _extract_detection_score,
+    _extract_detection_method,
+    _set_darwin_span_attributes,
+    darwin_trace,
+    DARWIN_METRIC_PREFIX,
+)
+
+
+class MockSpan:
+    """Mock OTEL span for testing attribute setting."""
+
+    def __init__(self):
+        self.attributes = {}
+
+    def set_attribute(self, key: str, value):
+        self.attributes[key] = value
+
+
+class MockTracer:
+    """Mock OTEL tracer for testing darwin_trace decorator."""
+
+    def __init__(self):
+        self.spans = []
+        self._current_span = None
+
+    @contextmanager
+    def start_as_current_span(self, name: str):
+        span = MockSpan()
+        span.name = name
+        self.spans.append(span)
+        self._current_span = span
+        yield span
+        self._current_span = None
+
+
+@pytest.fixture
+def mock_tracer():
+    return MockTracer()
+
+
+@pytest.fixture
+def flagged_guardrail_result():
+    """Create a flagged GuardrailResult with detection details."""
+    detection_result = DetectionTimingResult(
+        hit=True,
+        result={
+            "score": 0.92,
+            "response_string": "Blocked by prompt injection detector",
+        },
+        exec_time=45.0,
+    )
+    guard_result = GuardResult(
+        triggered=True,
+        details={"PromptInjectionDeberta": detection_result},
+        exec_time=0.05,
+        response="Guard:prompt-injection Blocked by prompt injection detector",
+    )
+    return GuardrailResult(
+        flagged=True,
+        guardrail_response_message="Blocked by input guardrail",
+        exec_time=0.06,
+        guard_exec_details={"prompt-injection": guard_result},
+    )
+
+
+@pytest.fixture
+def clean_guardrail_result():
+    """Create a clean (not flagged) GuardrailResult."""
+    detection_result = DetectionTimingResult(
+        hit=False,
+        result={"score": 0.15, "response_string": "What is the weather?"},
+        exec_time=30.0,
+    )
+    guard_result = GuardResult(
+        triggered=False,
+        details={"PromptInjectionDeberta": detection_result},
+        exec_time=0.03,
+        response="What is the weather?",
+    )
+    return GuardrailResult(
+        flagged=False,
+        guardrail_response_message="What is the weather?",
+        exec_time=0.04,
+        guard_exec_details={"prompt-injection": guard_result},
+    )
+
+
+class TestExtractDetectionScore:
+    """Tests for _extract_detection_score function."""
+
+    def test_extracts_score_from_flagged_guardrail_result(self, flagged_guardrail_result):
+        score = _extract_detection_score(flagged_guardrail_result)
+        assert score == 0.92
+
+    def test_returns_zero_for_clean_result(self, clean_guardrail_result):
+        # Clean results return 0.0 because we only extract scores from
+        # triggered guards - Darwin only cares about flagged detection scores
+        score = _extract_detection_score(clean_guardrail_result)
+        assert score == 0.0
+
+    def test_returns_max_score_from_multiple_guards(self):
+        """When multiple guards trigger, return the highest score."""
+        detection1 = DetectionTimingResult(
+            hit=True, result={"score": 0.75}, exec_time=20.0
+        )
+        detection2 = DetectionTimingResult(
+            hit=True, result={"score": 0.95}, exec_time=25.0
+        )
+        guard1 = GuardResult(
+            triggered=True,
+            details={"Detector1": detection1},
+            exec_time=0.02,
+            response="Blocked",
+        )
+        guard2 = GuardResult(
+            triggered=True,
+            details={"Detector2": detection2},
+            exec_time=0.03,
+            response="Blocked",
+        )
+        result = GuardrailResult(
+            flagged=True,
+            guardrail_response_message="Blocked",
+            exec_time=0.05,
+            guard_exec_details={"guard1": guard1, "guard2": guard2},
+        )
+
+        score = _extract_detection_score(result)
+        assert score == 0.95
+
+    def test_handles_guard_result_directly(self):
+        """Test with GuardResult instead of GuardrailResult."""
+        detection = DetectionTimingResult(
+            hit=True, result={"score": 0.88}, exec_time=15.0
+        )
+        guard_result = GuardResult(
+            triggered=True,
+            details={"ToxicityDetector": detection},
+            exec_time=0.02,
+            response="Blocked",
+        )
+
+        score = _extract_detection_score(guard_result)
+        assert score == 0.88
+
+
+class TestExtractDetectionMethod:
+    """Tests for _extract_detection_method function."""
+
+    def test_extracts_guard_name_from_flagged_result(self, flagged_guardrail_result):
+        method = _extract_detection_method(flagged_guardrail_result)
+        assert method == "prompt-injection"
+
+    def test_returns_unknown_for_clean_result(self, clean_guardrail_result):
+        method = _extract_detection_method(clean_guardrail_result)
+        assert method == "unknown"
+
+    def test_returns_first_triggered_guard(self):
+        """When multiple guards trigger, return the first one found."""
+        detection = DetectionTimingResult(
+            hit=True, result={"score": 0.90}, exec_time=20.0
+        )
+        guard1 = GuardResult(
+            triggered=True,
+            details={"Detector": detection},
+            exec_time=0.02,
+            response="Blocked",
+        )
+        guard2 = GuardResult(
+            triggered=True,
+            details={"Detector": detection},
+            exec_time=0.03,
+            response="Blocked",
+        )
+        result = GuardrailResult(
+            flagged=True,
+            guardrail_response_message="Blocked",
+            exec_time=0.05,
+            guard_exec_details={"jailbreak": guard1, "toxicity": guard2},
+        )
+
+        method = _extract_detection_method(result)
+        # Should be one of the triggered guards (dict iteration order)
+        assert method in ["jailbreak", "toxicity"]
+
+
+class TestSetDarwinSpanAttributes:
+    """Tests for _set_darwin_span_attributes function."""
+
+    def test_sets_all_darwin_attributes_on_flagged_result(
+        self, flagged_guardrail_result
+    ):
+        span = MockSpan()
+
+        _set_darwin_span_attributes(
+            span,
+            flagged_guardrail_result,
+            agent_id="agent-test-123",
+            team_id="team-abc-456",
+        )
+
+        assert span.attributes["team.id"] == "team-abc-456"
+        assert span.attributes["agent.id"] == "agent-test-123"
+        assert span.attributes["detection.label"] == "flagged"
+        assert span.attributes["detection.score"] == 0.92
+        assert span.attributes["detection.method"] == "prompt-injection"
+
+    def test_sets_clean_label_on_clean_result(self, clean_guardrail_result):
+        span = MockSpan()
+
+        _set_darwin_span_attributes(span, clean_guardrail_result)
+
+        assert span.attributes["detection.label"] == "clean"
+
+    def test_omits_missing_context_ids(self, flagged_guardrail_result):
+        span = MockSpan()
+
+        _set_darwin_span_attributes(span, flagged_guardrail_result)
+
+        assert "team.id" not in span.attributes
+        assert "agent.id" not in span.attributes
+        assert "detection.label" in span.attributes
+        assert "detection.score" in span.attributes
+
+
+class TestDarwinTraceDecorator:
+    """Tests for darwin_trace decorator."""
+
+    def test_creates_span_with_correct_name(self, mock_tracer, flagged_guardrail_result):
+        @darwin_trace(mock_tracer, "input-guardrail.scan")
+        def scan_function(text, agent_id=None, team_id=None):
+            return flagged_guardrail_result
+
+        result = scan_function("test input", agent_id="agent-1", team_id="team-1")
+
+        assert len(mock_tracer.spans) == 1
+        assert mock_tracer.spans[0].name == "input-guardrail.scan"
+
+    def test_sets_generic_attributes(self, mock_tracer, flagged_guardrail_result):
+        @darwin_trace(mock_tracer, "test.scan")
+        def scan_function(text, agent_id=None):
+            return flagged_guardrail_result
+
+        scan_function("hello world", agent_id="agent-x")
+
+        span = mock_tracer.spans[0]
+        assert "function.args" in span.attributes
+        assert "function.kwargs" in span.attributes
+        assert "function.result" in span.attributes
+
+    def test_sets_darwin_attributes_for_guardrail_result(
+        self, mock_tracer, flagged_guardrail_result
+    ):
+        @darwin_trace(mock_tracer, "input-guardrail.scan")
+        def scan_function(text, agent_id=None, team_id=None):
+            return flagged_guardrail_result
+
+        scan_function("test", agent_id="agent-1", team_id="team-1")
+
+        span = mock_tracer.spans[0]
+        assert span.attributes["detection.label"] == "flagged"
+        assert span.attributes["detection.score"] == 0.92
+        assert span.attributes["detection.method"] == "prompt-injection"
+        assert span.attributes["agent.id"] == "agent-1"
+        assert span.attributes["team.id"] == "team-1"
+
+    def test_skips_darwin_attributes_for_non_guardrail_result(self, mock_tracer):
+        @darwin_trace(mock_tracer, "other.function")
+        def other_function(text):
+            return {"result": "not a guardrail result"}
+
+        other_function("test")
+
+        span = mock_tracer.spans[0]
+        # Should have generic attributes but NOT Darwin-specific ones
+        assert "function.result" in span.attributes
+        assert "detection.label" not in span.attributes
+        assert "detection.score" not in span.attributes
+
+    @pytest.mark.asyncio
+    async def test_works_with_async_functions(
+        self, mock_tracer, flagged_guardrail_result
+    ):
+        @darwin_trace(mock_tracer, "async.scan")
+        async def async_scan(text, agent_id=None, team_id=None):
+            return flagged_guardrail_result
+
+        result = await async_scan("test", agent_id="agent-async", team_id="team-async")
+
+        assert len(mock_tracer.spans) == 1
+        span = mock_tracer.spans[0]
+        assert span.attributes["detection.label"] == "flagged"
+        assert span.attributes["agent.id"] == "agent-async"
+
+
+class TestDarwinMetricPrefix:
+    """Tests for metric naming convention."""
+
+    def test_darwin_metric_prefix_is_dome(self):
+        assert DARWIN_METRIC_PREFIX == "dome"


### PR DESCRIPTION
## Summary

Add telemetry module that emits structured span attributes Darwin can query to trigger evolution mutations from Dome detections.

- `darwin_trace()` decorator emits both generic and Darwin-specific span attributes
- `instrument_for_darwin()` patches existing guardrails with Darwin telemetry
- Darwin-compatible metrics with `dome-` prefix
- 16 unit tests, all passing

## Problem

Darwin's `TelemetryDetectionAdapter` expects structured span attributes (`detection.score`, `detection.label`, `detection.method`) but Dome's current instrumentation dumps `function.result` as a string. This causes Darwin to fail parsing Dome detections for evolution triggers.

## Solution

New module `vijil_dome/integrations/vijil/telemetry.py` provides:

| Component | Purpose |
|-----------|---------|
| `darwin_trace()` | Decorator that emits both generic and Darwin-specific attributes |
| `instrument_for_darwin()` | Patches existing guardrails with Darwin telemetry |
| `create_darwin_*()` | Metric creators with `dome-` prefix |

### Span Attributes Emitted

| Attribute | Type | Example |
|-----------|------|---------|
| `detection.score` | float | `0.92` |
| `detection.label` | string | `"flagged"` or `"clean"` |
| `detection.method` | string | `"prompt-injection"` |
| `team.id` | string | `"7295f905-..."` |
| `agent.id` | string | `"agent-cs-helpdesk"` |

## Usage

```python
from vijil_dome import Dome
from vijil_dome.integrations.vijil.telemetry import instrument_for_darwin
from opentelemetry import trace, metrics

dome = Dome(config)
tracer = trace.get_tracer("service-dome")
meter = metrics.get_meter("service-dome")

instrument_for_darwin(dome.input_guardrail, tracer, meter)
instrument_for_darwin(dome.output_guardrail, tracer, meter)
```

## Test plan

- [x] 16 unit tests covering all functions
- [ ] Integration test with service_dome (separate Console PR)
- [ ] E2E test: Dome detection → Darwin mutation proposal

## Related

- **Linear**: [DOME-63](https://linear.app/vijil/issue/DOME-63)
- **Design doc**: `docs/plans/2026-02-04-darwin-telemetry-integration-design.md`
- **Console PR**: (TBD - will update service_dome to use this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)