### PR TITLE
Expose base urls for safeguard detectors

### DIFF
--- a/vijil_dome/detectors/DETECTOR_INFO.md
+++ b/vijil_dome/detectors/DETECTOR_INFO.md
@@ -57,17 +57,24 @@ tokens natively, so sliding windows only activate for very long inputs.
 
 ### `prompt-injection-mbert-safeguard`
 
-API-only prompt injection detection using GPT-OSS-Safeguard-20B via Groq.
-~200ms latency, high accuracy, no ModernBERT loaded. Oversize inputs are
-truncated (not chunked) to `max_input_chars` before being sent — the
-~130K token context window makes truncation a rare safety net.
+API-only prompt injection detection backed by an OpenAI-compatible chat
+completions endpoint. Defaults to GPT-OSS-Safeguard-20B on Groq
+(~200ms, high accuracy), but `base_url`, `model`, and `api_key_name`
+can be overridden to point at any OpenAI-style deployment (local vLLM,
+Together, Fireworks, OpenAI itself, ...). No ModernBERT loaded.
+Oversize inputs are truncated (not chunked) to `max_input_chars` before
+being sent — the default Groq model's ~130K token context window makes
+truncation a rare safety net.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `groq_api_key` | `str` | `None` | Groq API key (falls back to `GROQ_API_KEY`) |
-| `groq_model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Groq model ID |
+| `api_key` | `str` | `None` | API key; falls back to the env var named by `api_key_name` |
+| `api_key_name` | `str` | `"GROQ_API_KEY"` | Name of the env var to read the API key from when `api_key` is not supplied |
+| `base_url` | `str` | `"https://api.groq.com/openai/v1"` | OpenAI-compatible base URL (`/chat/completions` is appended) |
+| `model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Model ID sent to the endpoint |
 | `temperature` | `float` | `0.0` | Sampling temperature |
 | `max_tokens` | `int` | `2000` | Response token budget (must leave room for reasoning tokens — see note below) |
+| `reasoning_effort` | `str \| None` | `"low"` | Passed through when non-null; set to `null` (JSON) / `None` (Python) to omit (required for non-reasoning models like `gpt-4o-mini`) |
 | `timeout_seconds` | `float` | `10.0` | Request timeout |
 | `max_input_chars` | `int` | `400000` | Character cap applied before the request (pass `None` to disable) |
 
@@ -78,7 +85,7 @@ truncated (not chunked) to `max_input_chars` before being sent — the
 > which the detector silently classifies as safe. Keep this generous.
 
 - **Class**: `PImbertSafeguard`
-- **Requires**: `GROQ_API_KEY` environment variable
+- **Requires**: the env var named by `api_key_name` (defaults to `GROQ_API_KEY`)
 
 ### `prompt-injection-mbert-hybrid`
 
@@ -95,10 +102,13 @@ parameters from both `prompt-injection-mbert` and
 | `truncation` | `bool` | `True` | Truncate inputs exceeding `max_length` |
 | `max_length` | `int` | `8192` | Maximum tokens per window (fast stage) |
 | `window_stride` | `int` | `4096` | Token step size between sliding windows |
-| `groq_api_key` | `str` | `None` | Groq API key (falls back to `GROQ_API_KEY`) |
-| `groq_model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Groq model ID |
+| `api_key` | `str` | `None` | API key; falls back to the env var named by `api_key_name` |
+| `api_key_name` | `str` | `"GROQ_API_KEY"` | Name of the env var to read the API key from when `api_key` is not supplied |
+| `base_url` | `str` | `"https://api.groq.com/openai/v1"` | OpenAI-compatible base URL (`/chat/completions` is appended) |
+| `model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Model ID sent to the endpoint |
 | `temperature` | `float` | `0.0` | Sampling temperature |
 | `max_tokens` | `int` | `2000` | Response token budget for the Safeguard escalation |
+| `reasoning_effort` | `str \| None` | `"low"` | Passed through when non-null; set to `null` (JSON) / `None` (Python) to omit (required for non-reasoning models like `gpt-4o-mini`) |
 | `timeout_seconds` | `float` | `10.0` | Request timeout |
 | `max_input_chars` | `int` | `400000` | Character cap applied before the escalation request |
 
@@ -107,7 +117,7 @@ fast-only classification instead of failing.
 
 - **Class**: `PImbertHybrid`
 - **Model**: [vijil/vijil_dome_prompt_injection_detection](https://huggingface.co/vijil/vijil_dome_prompt_injection_detection)
-- **Requires**: `GROQ_API_KEY` environment variable (optional; falls back to fast-only if absent)
+- **Requires**: the env var named by `api_key_name` (defaults to `GROQ_API_KEY`); optional — falls back to fast-only if absent
 
 ### `security-promptguard`
 
@@ -244,17 +254,24 @@ tokens natively.
 
 ### `moderation-mbert-safeguard`
 
-API-only toxicity / moderation detection using GPT-OSS-Safeguard-20B via
-Groq. ~200ms latency, high accuracy, no ModernBERT loaded. Oversize inputs
-are truncated (not chunked) to `max_input_chars` before being sent — the
-~130K token context window makes truncation a rare safety net.
+API-only toxicity / moderation detection backed by an OpenAI-compatible
+chat completions endpoint. Defaults to GPT-OSS-Safeguard-20B on Groq
+(~200ms, high accuracy), but `base_url`, `model`, and `api_key_name`
+can be overridden to point at any OpenAI-style deployment (local vLLM,
+Together, Fireworks, OpenAI itself, ...). No ModernBERT loaded.
+Oversize inputs are truncated (not chunked) to `max_input_chars` before
+being sent — the default Groq model's ~130K token context window makes
+truncation a rare safety net.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `groq_api_key` | `str` | `None` | Groq API key (falls back to `GROQ_API_KEY`) |
-| `groq_model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Groq model ID |
+| `api_key` | `str` | `None` | API key; falls back to the env var named by `api_key_name` |
+| `api_key_name` | `str` | `"GROQ_API_KEY"` | Name of the env var to read the API key from when `api_key` is not supplied |
+| `base_url` | `str` | `"https://api.groq.com/openai/v1"` | OpenAI-compatible base URL (`/chat/completions` is appended) |
+| `model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Model ID sent to the endpoint |
 | `temperature` | `float` | `0.0` | Sampling temperature |
 | `max_tokens` | `int` | `2000` | Response token budget (must leave room for reasoning tokens — see note below) |
+| `reasoning_effort` | `str \| None` | `"low"` | Passed through when non-null; set to `null` (JSON) / `None` (Python) to omit (required for non-reasoning models like `gpt-4o-mini`) |
 | `timeout_seconds` | `float` | `10.0` | Request timeout |
 | `max_input_chars` | `int` | `400000` | Character cap applied before the request (pass `None` to disable) |
 
@@ -265,7 +282,7 @@ are truncated (not chunked) to `max_input_chars` before being sent — the
 > which the detector silently classifies as safe. Keep this generous.
 
 - **Class**: `ModerationMbertSafeguard`
-- **Requires**: `GROQ_API_KEY` environment variable
+- **Requires**: the env var named by `api_key_name` (defaults to `GROQ_API_KEY`)
 
 ### `moderation-mbert-hybrid`
 
@@ -281,10 +298,13 @@ parameters from both `moderation-mbert` and `moderation-mbert-safeguard`.
 | `truncation` | `bool` | `True` | Truncate inputs exceeding `max_length` |
 | `max_length` | `int` | `8192` | Maximum tokens per window (fast stage) |
 | `window_stride` | `int` | `4096` | Token step size between sliding windows |
-| `groq_api_key` | `str` | `None` | Groq API key (falls back to `GROQ_API_KEY`) |
-| `groq_model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Groq model ID |
+| `api_key` | `str` | `None` | API key; falls back to the env var named by `api_key_name` |
+| `api_key_name` | `str` | `"GROQ_API_KEY"` | Name of the env var to read the API key from when `api_key` is not supplied |
+| `base_url` | `str` | `"https://api.groq.com/openai/v1"` | OpenAI-compatible base URL (`/chat/completions` is appended) |
+| `model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Model ID sent to the endpoint |
 | `temperature` | `float` | `0.0` | Sampling temperature |
 | `max_tokens` | `int` | `2000` | Response token budget for the Safeguard escalation |
+| `reasoning_effort` | `str \| None` | `"low"` | Passed through when non-null; set to `null` (JSON) / `None` (Python) to omit (required for non-reasoning models like `gpt-4o-mini`) |
 | `timeout_seconds` | `float` | `10.0` | Request timeout |
 | `max_input_chars` | `int` | `400000` | Character cap applied before the escalation request |
 
@@ -293,7 +313,7 @@ fast-only classification instead of failing.
 
 - **Class**: `ModerationMbertHybrid`
 - **Model**: [vijil/vijil_dome_toxic_content_detection](https://huggingface.co/vijil/vijil_dome_toxic_content_detection)
-- **Requires**: `GROQ_API_KEY` environment variable (optional; falls back to fast-only if absent)
+- **Requires**: the env var named by `api_key_name` (defaults to `GROQ_API_KEY`); optional — falls back to fast-only if absent
 
 ### `moderations-oai-api`
 
@@ -379,17 +399,24 @@ any chunk flagged flags the whole input, and the max score wins.
 
 ### `stereotype-eeoc-safeguard`
 
-API-only EEOC stereotype detection using GPT-OSS-Safeguard-20B via Groq.
-~200ms latency, ~100% accuracy, no ModernBERT loaded. Oversize inputs are
-truncated (not chunked) to `max_input_chars` before being sent — the
-~130K token context window makes truncation a rare safety net.
+API-only EEOC stereotype detection backed by an OpenAI-compatible chat
+completions endpoint. Defaults to GPT-OSS-Safeguard-20B on Groq
+(~200ms, ~100% accuracy), but `base_url`, `model`, and `api_key_name`
+can be overridden to point at any OpenAI-style deployment (local vLLM,
+Together, Fireworks, OpenAI itself, ...). No ModernBERT loaded.
+Oversize inputs are truncated (not chunked) to `max_input_chars` before
+being sent — the default Groq model's ~130K token context window makes
+truncation a rare safety net.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `groq_api_key` | `str` | `None` | Groq API key (falls back to `GROQ_API_KEY`) |
-| `groq_model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Groq model ID |
+| `api_key` | `str` | `None` | API key; falls back to the env var named by `api_key_name` |
+| `api_key_name` | `str` | `"GROQ_API_KEY"` | Name of the env var to read the API key from when `api_key` is not supplied |
+| `base_url` | `str` | `"https://api.groq.com/openai/v1"` | OpenAI-compatible base URL (`/chat/completions` is appended) |
+| `model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Model ID sent to the endpoint |
 | `temperature` | `float` | `0.0` | Sampling temperature |
 | `max_tokens` | `int` | `2000` | Response token budget (must leave room for reasoning tokens — see note below) |
+| `reasoning_effort` | `str \| None` | `"low"` | Passed through when non-null; set to `null` (JSON) / `None` (Python) to omit (required for non-reasoning models like `gpt-4o-mini`) |
 | `timeout_seconds` | `float` | `10.0` | Request timeout |
 | `max_input_chars` | `int` | `400000` | Character cap applied before the request (pass `None` to disable) |
 
@@ -400,7 +427,7 @@ truncated (not chunked) to `max_input_chars` before being sent — the
 > which the detector silently classifies as safe. Keep this generous.
 
 - **Class**: `StereotypeEEOCSafeguard`
-- **Requires**: `GROQ_API_KEY` environment variable
+- **Requires**: the env var named by `api_key_name` (defaults to `GROQ_API_KEY`)
 
 ### `stereotype-eeoc-hybrid`
 
@@ -414,10 +441,13 @@ parameters from both `stereotype-eeoc-fast` and `stereotype-eeoc-safeguard`.
 | `confidence_threshold` | `float` | `0.85` | Fast-stage confidence below which the input is escalated to Safeguard |
 | `score_threshold` | `float` | `0.5` | Stereotype probability threshold (fast stage) |
 | `max_length` | `int` | `512` | Maximum tokens per chunk (fast stage) |
-| `groq_api_key` | `str` | `None` | Groq API key (falls back to `GROQ_API_KEY`) |
-| `groq_model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Groq model ID |
+| `api_key` | `str` | `None` | API key; falls back to the env var named by `api_key_name` |
+| `api_key_name` | `str` | `"GROQ_API_KEY"` | Name of the env var to read the API key from when `api_key` is not supplied |
+| `base_url` | `str` | `"https://api.groq.com/openai/v1"` | OpenAI-compatible base URL (`/chat/completions` is appended) |
+| `model` | `str` | `"openai/gpt-oss-safeguard-20b"` | Model ID sent to the endpoint |
 | `temperature` | `float` | `0.0` | Sampling temperature |
 | `max_tokens` | `int` | `2000` | Response token budget for the Safeguard escalation |
+| `reasoning_effort` | `str \| None` | `"low"` | Passed through when non-null; set to `null` (JSON) / `None` (Python) to omit (required for non-reasoning models like `gpt-4o-mini`) |
 | `timeout_seconds` | `float` | `10.0` | Request timeout |
 | `max_input_chars` | `int` | `400000` | Character cap applied before the escalation request |
 
@@ -426,7 +456,7 @@ fast-only classification instead of failing.
 
 - **Class**: `StereotypeEEOCHybrid`
 - **Model**: [vijil/stereotype-eeoc-detector](https://huggingface.co/vijil/stereotype-eeoc-detector)
-- **Requires**: `GROQ_API_KEY` environment variable (optional; falls back to fast-only if absent)
+- **Requires**: the env var named by `api_key_name` (defaults to `GROQ_API_KEY`); optional — falls back to fast-only if absent
 
 ---
 

--- a/vijil_dome/detectors/methods/pi_hf_mbert.py
+++ b/vijil_dome/detectors/methods/pi_hf_mbert.py
@@ -66,7 +66,13 @@ DEFAULT_SAFEGUARD_TEMPERATURE = 0.0
 DEFAULT_SAFEGUARD_MAX_TOKENS = 2000
 DEFAULT_SAFEGUARD_MAX_INPUT_CHARS = 400_000
 
-GROQ_CHAT_COMPLETIONS_URL = "https://api.groq.com/openai/v1/chat/completions"
+# The safeguard endpoint is OpenAI-compatible. Groq is the default, but
+# callers can point at any OpenAI-compatible `/chat/completions` endpoint
+# (local vLLM, Together, Fireworks, OpenAI itself, ...) by overriding
+# `base_url`, `model`, and `api_key_name` on the detector.
+DEFAULT_SAFEGUARD_API_KEY_NAME = "GROQ_API_KEY"
+DEFAULT_SAFEGUARD_BASE_URL = "https://api.groq.com/openai/v1"
+DEFAULT_SAFEGUARD_MODEL = "openai/gpt-oss-safeguard-20b"
 
 
 # ----------------------------------------------------------------------
@@ -297,35 +303,48 @@ class MBertPromptInjectionModel(HFBaseModel):
 @register_method(DetectionCategory.Security, PI_MBERT_SAFEGUARD)
 class PImbertSafeguard(DetectionMethod):
     """
-    Prompt injection detection using GPT-OSS-Safeguard-20B via Groq.
-    ~200ms latency, high accuracy, requires GROQ_API_KEY.
+    Prompt injection detection backed by an OpenAI-compatible chat
+    completions endpoint. Defaults to GPT-OSS-Safeguard-20B on Groq
+    (~200ms, high accuracy), but the endpoint, model, and credential
+    name are all overridable so callers can point at any OpenAI-style
+    deployment (local vLLM, Together, Fireworks, OpenAI proper, ...).
 
     Does not load ModernBERT \u2014 this mode is API-only.
     """
 
     def __init__(
         self,
-        groq_api_key: Optional[str] = None,
-        groq_model: str = "openai/gpt-oss-safeguard-20b",
+        api_key: Optional[str] = None,
+        api_key_name: str = DEFAULT_SAFEGUARD_API_KEY_NAME,
+        base_url: str = DEFAULT_SAFEGUARD_BASE_URL,
+        model: str = DEFAULT_SAFEGUARD_MODEL,
         temperature: float = DEFAULT_SAFEGUARD_TEMPERATURE,
         max_tokens: int = DEFAULT_SAFEGUARD_MAX_TOKENS,
+        reasoning_effort: Optional[str] = "low",
         timeout_seconds: float = 10.0,
         max_input_chars: Optional[int] = DEFAULT_SAFEGUARD_MAX_INPUT_CHARS,
         **kwargs,
     ):
-        self.groq_api_key = groq_api_key or os.environ.get("GROQ_API_KEY", "")
-        self.groq_model = groq_model
+        self.api_key_name = api_key_name
+        self.api_key = api_key or os.environ.get(api_key_name, "")
+        self.base_url = base_url.rstrip("/")
+        self.chat_completions_url = f"{self.base_url}/chat/completions"
+        self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.reasoning_effort = reasoning_effort
         self.timeout_seconds = timeout_seconds
         self.max_input_chars = max_input_chars
         self.response_string = f"Method:{PI_MBERT_SAFEGUARD}"
         self.run_in_executor = False
-        if not self.groq_api_key:
+        if not self.api_key:
             logger.warning(
-                f"GROQ_API_KEY not set \u2014 {PI_MBERT_SAFEGUARD} will fail at runtime"
+                f"{api_key_name} not set \u2014 {PI_MBERT_SAFEGUARD} will fail at runtime"
             )
-        logger.info("Initialized PI mbert detector (Safeguard mode)")
+        logger.info(
+            "Initialized PI mbert detector "
+            f"(Safeguard mode, model={model}, base_url={self.base_url})"
+        )
 
     def _truncate_if_needed(self, text: str) -> str:
         if self.max_input_chars is not None and len(text) > self.max_input_chars:
@@ -337,28 +356,30 @@ class PImbertSafeguard(DetectionMethod):
             return text[: self.max_input_chars]
         return text
 
-    def _groq_payload(self, query_string: str) -> dict:
-        return {
-            "model": self.groq_model,
+    def _build_payload(self, query_string: str) -> dict:
+        payload = {
+            "model": self.model,
             "messages": [
                 {"role": "system", "content": PI_SAFEGUARD_SYSTEM_PROMPT},
                 {"role": "user", "content": query_string},
             ],
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
-            "reasoning_effort": "low",
         }
+        if self.reasoning_effort is not None:
+            payload["reasoning_effort"] = self.reasoning_effort
+        return payload
 
     async def _call_safeguard(
         self, client: httpx.AsyncClient, query_string: str
     ) -> str:
         resp = await client.post(
-            GROQ_CHAT_COMPLETIONS_URL,
+            self.chat_completions_url,
             headers={
-                "Authorization": f"Bearer {self.groq_api_key}",
+                "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/json",
             },
-            json=self._groq_payload(query_string),
+            json=self._build_payload(query_string),
         )
         resp.raise_for_status()
         return resp.json()["choices"][0]["message"].get("content", "").strip().lower()
@@ -414,32 +435,40 @@ class PImbertHybrid(MBertPromptInjectionModel):
     def __init__(
         self,
         confidence_threshold: float = 0.85,
-        groq_api_key: Optional[str] = None,
-        groq_model: str = "openai/gpt-oss-safeguard-20b",
+        api_key: Optional[str] = None,
+        api_key_name: str = DEFAULT_SAFEGUARD_API_KEY_NAME,
+        base_url: str = DEFAULT_SAFEGUARD_BASE_URL,
+        model: str = DEFAULT_SAFEGUARD_MODEL,
         temperature: float = DEFAULT_SAFEGUARD_TEMPERATURE,
         max_tokens: int = DEFAULT_SAFEGUARD_MAX_TOKENS,
+        reasoning_effort: Optional[str] = "low",
         timeout_seconds: float = 10.0,
         max_input_chars: Optional[int] = DEFAULT_SAFEGUARD_MAX_INPUT_CHARS,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.confidence_threshold = confidence_threshold
-        self.groq_api_key = groq_api_key or os.environ.get("GROQ_API_KEY", "")
-        self.groq_model = groq_model
+        self.api_key_name = api_key_name
+        self.api_key = api_key or os.environ.get(api_key_name, "")
+        self.base_url = base_url.rstrip("/")
+        self.chat_completions_url = f"{self.base_url}/chat/completions"
+        self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.reasoning_effort = reasoning_effort
         self.timeout_seconds = timeout_seconds
         self.max_input_chars = max_input_chars
         self.response_string = f"Method:{PI_MBERT_HYBRID}"
         self.run_in_executor = False  # async for Safeguard fallback
 
-        if not self.groq_api_key:
+        if not self.api_key:
             logger.warning(
-                f"GROQ_API_KEY not set \u2014 {PI_MBERT_HYBRID} will fall back to fast-only"
+                f"{api_key_name} not set \u2014 {PI_MBERT_HYBRID} will fall back to fast-only"
             )
         logger.info(
             "Initialized PI mbert detector "
-            f"(hybrid mode, confidence_threshold={confidence_threshold})"
+            f"(hybrid mode, confidence_threshold={confidence_threshold}, "
+            f"model={model}, base_url={self.base_url})"
         )
 
     # ------------------------------------------------------------------
@@ -512,23 +541,25 @@ class PImbertHybrid(MBertPromptInjectionModel):
     ) -> DetectionResult:
         """Run Safeguard on one low-confidence item, with graceful fallback."""
         query_string = self._truncate_if_needed(dome_input.query_string)
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": PI_SAFEGUARD_SYSTEM_PROMPT},
+                {"role": "user", "content": query_string},
+            ],
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+        if self.reasoning_effort is not None:
+            payload["reasoning_effort"] = self.reasoning_effort
         try:
             resp = await client.post(
-                GROQ_CHAT_COMPLETIONS_URL,
+                self.chat_completions_url,
                 headers={
-                    "Authorization": f"Bearer {self.groq_api_key}",
+                    "Authorization": f"Bearer {self.api_key}",
                     "Content-Type": "application/json",
                 },
-                json={
-                    "model": self.groq_model,
-                    "messages": [
-                        {"role": "system", "content": PI_SAFEGUARD_SYSTEM_PROMPT},
-                        {"role": "user", "content": query_string},
-                    ],
-                    "temperature": self.temperature,
-                    "max_tokens": self.max_tokens,
-                    "reasoning_effort": "low",
-                },
+                json=payload,
             )
             resp.raise_for_status()
             content = (
@@ -572,7 +603,7 @@ class PImbertHybrid(MBertPromptInjectionModel):
             )
 
         # Low confidence -> escalate to Safeguard if we have a key.
-        if not self.groq_api_key:
+        if not self.api_key:
             flagged = score >= self.score_threshold
             return flagged, self._fast_payload(
                 dome_input, score, prediction, stage="fast-fallback"
@@ -615,7 +646,7 @@ class PImbertHybrid(MBertPromptInjectionModel):
                     flagged,
                     self._fast_payload(dome_input, score, prediction, stage="fast"),
                 )
-            elif not self.groq_api_key:
+            elif not self.api_key:
                 flagged = score >= self.score_threshold
                 results[idx] = (
                     flagged,

--- a/vijil_dome/detectors/methods/stereotype_eeoc.py
+++ b/vijil_dome/detectors/methods/stereotype_eeoc.py
@@ -120,7 +120,13 @@ _SEP_STRING_TOKEN_BUDGET = 6
 # Model special-token overhead (CLS + SEP emitted by the tokenizer).
 _SPECIAL_TOKEN_OVERHEAD = 2
 
-GROQ_CHAT_COMPLETIONS_URL = "https://api.groq.com/openai/v1/chat/completions"
+# The safeguard endpoint is OpenAI-compatible. Groq is the default, but
+# callers can point at any OpenAI-compatible `/chat/completions` endpoint
+# (local vLLM, Together, Fireworks, OpenAI itself, ...) by overriding
+# `base_url`, `model`, and `api_key_name` on the detector.
+DEFAULT_SAFEGUARD_API_KEY_NAME = "GROQ_API_KEY"
+DEFAULT_SAFEGUARD_BASE_URL = "https://api.groq.com/openai/v1"
+DEFAULT_SAFEGUARD_MODEL = "openai/gpt-oss-safeguard-20b"
 
 
 class StereotypeEEOCBase(HFBaseModel):
@@ -434,42 +440,55 @@ class StereotypeEEOCFast(StereotypeEEOCBase):
 @register_method(DetectionCategory.Moderation, STEREOTYPE_EEOC_SAFEGUARD)
 class StereotypeEEOCSafeguard(DetectionMethod):
     """
-    Accurate EEOC stereotype detection using GPT-OSS-Safeguard-20B via Groq.
-    ~200ms latency, ~100% accuracy, requires GROQ_API_KEY.
+    Accurate EEOC stereotype detection backed by an OpenAI-compatible chat
+    completions endpoint. Defaults to GPT-OSS-Safeguard-20B on Groq
+    (~200ms, ~100% accuracy), but the endpoint, model, and credential
+    name are all overridable so callers can point at any OpenAI-style
+    deployment (local vLLM, Together, Fireworks, OpenAI proper, ...).
 
     Does not load ModernBERT — this mode is API-only.
 
     Oversize inputs are **truncated** (not chunked) to ``max_input_chars``
-    before being sent to Groq, matching the convention used by other
-    API-backed detectors in this library (see ``LlmBaseDetector``). The
-    default is intentionally generous — GPT-OSS-Safeguard-20B has a
+    before being sent to the endpoint, matching the convention used by
+    other API-backed detectors in this library (see ``LlmBaseDetector``).
+    The default is intentionally generous — GPT-OSS-Safeguard-20B has a
     ~130K token context window, so truncation should be a rare
     safety-net rather than something callers hit routinely.
     """
 
     def __init__(
         self,
-        groq_api_key: Optional[str] = None,
-        groq_model: str = "openai/gpt-oss-safeguard-20b",
+        api_key: Optional[str] = None,
+        api_key_name: str = DEFAULT_SAFEGUARD_API_KEY_NAME,
+        base_url: str = DEFAULT_SAFEGUARD_BASE_URL,
+        model: str = DEFAULT_SAFEGUARD_MODEL,
         temperature: float = DEFAULT_SAFEGUARD_TEMPERATURE,
         max_tokens: int = DEFAULT_SAFEGUARD_MAX_TOKENS,
+        reasoning_effort: Optional[str] = "low",
         timeout_seconds: float = 10.0,
         max_input_chars: Optional[int] = DEFAULT_SAFEGUARD_MAX_INPUT_CHARS,
         **kwargs,
     ):
-        self.groq_api_key = groq_api_key or os.environ.get("GROQ_API_KEY", "")
-        self.groq_model = groq_model
+        self.api_key_name = api_key_name
+        self.api_key = api_key or os.environ.get(api_key_name, "")
+        self.base_url = base_url.rstrip("/")
+        self.chat_completions_url = f"{self.base_url}/chat/completions"
+        self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.reasoning_effort = reasoning_effort
         self.timeout_seconds = timeout_seconds
         self.max_input_chars = max_input_chars
         self.response_string = f"Method:{STEREOTYPE_EEOC_SAFEGUARD}"
         self.run_in_executor = False  # async HTTP, no executor needed
-        if not self.groq_api_key:
+        if not self.api_key:
             logger.warning(
-                f"GROQ_API_KEY not set — {STEREOTYPE_EEOC_SAFEGUARD} will fail at runtime"
+                f"{api_key_name} not set — {STEREOTYPE_EEOC_SAFEGUARD} will fail at runtime"
             )
-        logger.info("Initialized EEOC stereotype detector (Safeguard mode)")
+        logger.info(
+            "Initialized EEOC stereotype detector "
+            f"(Safeguard mode, model={model}, base_url={self.base_url})"
+        )
 
     def _truncate_if_needed(self, text: str) -> str:
         """Cap ``text`` at ``self.max_input_chars`` to stay under the
@@ -483,28 +502,30 @@ class StereotypeEEOCSafeguard(DetectionMethod):
             return text[: self.max_input_chars]
         return text
 
-    def _groq_payload(self, query_string: str) -> dict:
-        return {
-            "model": self.groq_model,
+    def _build_payload(self, query_string: str) -> dict:
+        payload = {
+            "model": self.model,
             "messages": [
                 {"role": "system", "content": SAFEGUARD_SYSTEM_PROMPT},
                 {"role": "user", "content": query_string},
             ],
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
-            "reasoning_effort": "low",
         }
+        if self.reasoning_effort is not None:
+            payload["reasoning_effort"] = self.reasoning_effort
+        return payload
 
     async def _call_safeguard(
         self, client: httpx.AsyncClient, query_string: str
     ) -> str:
         resp = await client.post(
-            GROQ_CHAT_COMPLETIONS_URL,
+            self.chat_completions_url,
             headers={
-                "Authorization": f"Bearer {self.groq_api_key}",
+                "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/json",
             },
-            json=self._groq_payload(query_string),
+            json=self._build_payload(query_string),
         )
         resp.raise_for_status()
         return resp.json()["choices"][0]["message"].get("content", "").strip().lower()
@@ -567,32 +588,40 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
     def __init__(
         self,
         confidence_threshold: float = 0.85,
-        groq_api_key: Optional[str] = None,
-        groq_model: str = "openai/gpt-oss-safeguard-20b",
+        api_key: Optional[str] = None,
+        api_key_name: str = DEFAULT_SAFEGUARD_API_KEY_NAME,
+        base_url: str = DEFAULT_SAFEGUARD_BASE_URL,
+        model: str = DEFAULT_SAFEGUARD_MODEL,
         temperature: float = DEFAULT_SAFEGUARD_TEMPERATURE,
         max_tokens: int = DEFAULT_SAFEGUARD_MAX_TOKENS,
+        reasoning_effort: Optional[str] = "low",
         timeout_seconds: float = 10.0,
         max_input_chars: Optional[int] = DEFAULT_SAFEGUARD_MAX_INPUT_CHARS,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.confidence_threshold = confidence_threshold
-        self.groq_api_key = groq_api_key or os.environ.get("GROQ_API_KEY", "")
-        self.groq_model = groq_model
+        self.api_key_name = api_key_name
+        self.api_key = api_key or os.environ.get(api_key_name, "")
+        self.base_url = base_url.rstrip("/")
+        self.chat_completions_url = f"{self.base_url}/chat/completions"
+        self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.reasoning_effort = reasoning_effort
         self.timeout_seconds = timeout_seconds
         self.max_input_chars = max_input_chars
         self.response_string = f"Method:{STEREOTYPE_EEOC_HYBRID}"
         self.run_in_executor = False  # async for Safeguard fallback
 
-        if not self.groq_api_key:
+        if not self.api_key:
             logger.warning(
-                f"GROQ_API_KEY not set — {STEREOTYPE_EEOC_HYBRID} will fall back to fast-only"
+                f"{api_key_name} not set — {STEREOTYPE_EEOC_HYBRID} will fall back to fast-only"
             )
         logger.info(
             "Initialized EEOC stereotype detector "
-            f"(hybrid mode, confidence_threshold={confidence_threshold})"
+            f"(hybrid mode, confidence_threshold={confidence_threshold}, "
+            f"model={model}, base_url={self.base_url})"
         )
 
     # Fast-stage payload builder — shared between detect and detect_batch.
@@ -661,23 +690,25 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
     ) -> DetectionResult:
         """Run Safeguard on one low-confidence item, with graceful fallback."""
         query_string = self._truncate_if_needed(dome_input.query_string)
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": SAFEGUARD_SYSTEM_PROMPT},
+                {"role": "user", "content": query_string},
+            ],
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+        if self.reasoning_effort is not None:
+            payload["reasoning_effort"] = self.reasoning_effort
         try:
             resp = await client.post(
-                GROQ_CHAT_COMPLETIONS_URL,
+                self.chat_completions_url,
                 headers={
-                    "Authorization": f"Bearer {self.groq_api_key}",
+                    "Authorization": f"Bearer {self.api_key}",
                     "Content-Type": "application/json",
                 },
-                json={
-                    "model": self.groq_model,
-                    "messages": [
-                        {"role": "system", "content": SAFEGUARD_SYSTEM_PROMPT},
-                        {"role": "user", "content": query_string},
-                    ],
-                    "temperature": self.temperature,
-                    "max_tokens": self.max_tokens,
-                    "reasoning_effort": "low",
-                },
+                json=payload,
             )
             resp.raise_for_status()
             content = (
@@ -716,7 +747,7 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
             return flagged, self._fast_payload(dome_input, score, prediction, stage="fast")
 
         # Low confidence → escalate to Safeguard if we have a key.
-        if not self.groq_api_key:
+        if not self.api_key:
             flagged = score >= self.score_threshold
             return flagged, self._fast_payload(
                 dome_input, score, prediction, stage="fast-fallback"
@@ -759,7 +790,7 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
                     flagged,
                     self._fast_payload(dome_input, score, prediction, stage="fast"),
                 )
-            elif not self.groq_api_key:
+            elif not self.api_key:
                 flagged = score >= self.score_threshold
                 results[idx] = (
                     flagged,

--- a/vijil_dome/detectors/methods/toxicity_mbert.py
+++ b/vijil_dome/detectors/methods/toxicity_mbert.py
@@ -64,7 +64,13 @@ DEFAULT_SAFEGUARD_TEMPERATURE = 0.0
 DEFAULT_SAFEGUARD_MAX_TOKENS = 2000
 DEFAULT_SAFEGUARD_MAX_INPUT_CHARS = 400_000
 
-GROQ_CHAT_COMPLETIONS_URL = "https://api.groq.com/openai/v1/chat/completions"
+# The safeguard endpoint is OpenAI-compatible. Groq is the default, but
+# callers can point at any OpenAI-compatible `/chat/completions` endpoint
+# (local vLLM, Together, Fireworks, OpenAI itself, ...) by overriding
+# `base_url`, `model`, and `api_key_name` on the detector.
+DEFAULT_SAFEGUARD_API_KEY_NAME = "GROQ_API_KEY"
+DEFAULT_SAFEGUARD_BASE_URL = "https://api.groq.com/openai/v1"
+DEFAULT_SAFEGUARD_MODEL = "openai/gpt-oss-safeguard-20b"
 
 
 # ----------------------------------------------------------------------
@@ -298,35 +304,48 @@ class MBertToxicContentModel(HFBaseModel):
 @register_method(DetectionCategory.Moderation, MODERATION_MBERT_SAFEGUARD)
 class ModerationMbertSafeguard(DetectionMethod):
     """
-    Toxicity / moderation detection using GPT-OSS-Safeguard-20B via Groq.
-    ~200ms latency, high accuracy, requires GROQ_API_KEY.
+    Toxicity / moderation detection backed by an OpenAI-compatible chat
+    completions endpoint. Defaults to GPT-OSS-Safeguard-20B on Groq
+    (~200ms, high accuracy), but the endpoint, model, and credential
+    name are all overridable so callers can point at any OpenAI-style
+    deployment (local vLLM, Together, Fireworks, OpenAI proper, ...).
 
     Does not load ModernBERT \u2014 this mode is API-only.
     """
 
     def __init__(
         self,
-        groq_api_key: Optional[str] = None,
-        groq_model: str = "openai/gpt-oss-safeguard-20b",
+        api_key: Optional[str] = None,
+        api_key_name: str = DEFAULT_SAFEGUARD_API_KEY_NAME,
+        base_url: str = DEFAULT_SAFEGUARD_BASE_URL,
+        model: str = DEFAULT_SAFEGUARD_MODEL,
         temperature: float = DEFAULT_SAFEGUARD_TEMPERATURE,
         max_tokens: int = DEFAULT_SAFEGUARD_MAX_TOKENS,
+        reasoning_effort: Optional[str] = "low",
         timeout_seconds: float = 10.0,
         max_input_chars: Optional[int] = DEFAULT_SAFEGUARD_MAX_INPUT_CHARS,
         **kwargs,
     ):
-        self.groq_api_key = groq_api_key or os.environ.get("GROQ_API_KEY", "")
-        self.groq_model = groq_model
+        self.api_key_name = api_key_name
+        self.api_key = api_key or os.environ.get(api_key_name, "")
+        self.base_url = base_url.rstrip("/")
+        self.chat_completions_url = f"{self.base_url}/chat/completions"
+        self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.reasoning_effort = reasoning_effort
         self.timeout_seconds = timeout_seconds
         self.max_input_chars = max_input_chars
         self.response_string = f"Method:{MODERATION_MBERT_SAFEGUARD}"
         self.run_in_executor = False
-        if not self.groq_api_key:
+        if not self.api_key:
             logger.warning(
-                f"GROQ_API_KEY not set \u2014 {MODERATION_MBERT_SAFEGUARD} will fail at runtime"
+                f"{api_key_name} not set \u2014 {MODERATION_MBERT_SAFEGUARD} will fail at runtime"
             )
-        logger.info("Initialized moderation mbert detector (Safeguard mode)")
+        logger.info(
+            "Initialized moderation mbert detector "
+            f"(Safeguard mode, model={model}, base_url={self.base_url})"
+        )
 
     def _truncate_if_needed(self, text: str) -> str:
         if self.max_input_chars is not None and len(text) > self.max_input_chars:
@@ -338,28 +357,30 @@ class ModerationMbertSafeguard(DetectionMethod):
             return text[: self.max_input_chars]
         return text
 
-    def _groq_payload(self, query_string: str) -> dict:
-        return {
-            "model": self.groq_model,
+    def _build_payload(self, query_string: str) -> dict:
+        payload = {
+            "model": self.model,
             "messages": [
                 {"role": "system", "content": MODERATION_SAFEGUARD_SYSTEM_PROMPT},
                 {"role": "user", "content": query_string},
             ],
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
-            "reasoning_effort": "low",
         }
+        if self.reasoning_effort is not None:
+            payload["reasoning_effort"] = self.reasoning_effort
+        return payload
 
     async def _call_safeguard(
         self, client: httpx.AsyncClient, query_string: str
     ) -> str:
         resp = await client.post(
-            GROQ_CHAT_COMPLETIONS_URL,
+            self.chat_completions_url,
             headers={
-                "Authorization": f"Bearer {self.groq_api_key}",
+                "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/json",
             },
-            json=self._groq_payload(query_string),
+            json=self._build_payload(query_string),
         )
         resp.raise_for_status()
         return resp.json()["choices"][0]["message"].get("content", "").strip().lower()
@@ -415,32 +436,40 @@ class ModerationMbertHybrid(MBertToxicContentModel):
     def __init__(
         self,
         confidence_threshold: float = 0.85,
-        groq_api_key: Optional[str] = None,
-        groq_model: str = "openai/gpt-oss-safeguard-20b",
+        api_key: Optional[str] = None,
+        api_key_name: str = DEFAULT_SAFEGUARD_API_KEY_NAME,
+        base_url: str = DEFAULT_SAFEGUARD_BASE_URL,
+        model: str = DEFAULT_SAFEGUARD_MODEL,
         temperature: float = DEFAULT_SAFEGUARD_TEMPERATURE,
         max_tokens: int = DEFAULT_SAFEGUARD_MAX_TOKENS,
+        reasoning_effort: Optional[str] = "low",
         timeout_seconds: float = 10.0,
         max_input_chars: Optional[int] = DEFAULT_SAFEGUARD_MAX_INPUT_CHARS,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.confidence_threshold = confidence_threshold
-        self.groq_api_key = groq_api_key or os.environ.get("GROQ_API_KEY", "")
-        self.groq_model = groq_model
+        self.api_key_name = api_key_name
+        self.api_key = api_key or os.environ.get(api_key_name, "")
+        self.base_url = base_url.rstrip("/")
+        self.chat_completions_url = f"{self.base_url}/chat/completions"
+        self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.reasoning_effort = reasoning_effort
         self.timeout_seconds = timeout_seconds
         self.max_input_chars = max_input_chars
         self.response_string = f"Method:{MODERATION_MBERT_HYBRID}"
         self.run_in_executor = False  # async for Safeguard fallback
 
-        if not self.groq_api_key:
+        if not self.api_key:
             logger.warning(
-                f"GROQ_API_KEY not set \u2014 {MODERATION_MBERT_HYBRID} will fall back to fast-only"
+                f"{api_key_name} not set \u2014 {MODERATION_MBERT_HYBRID} will fall back to fast-only"
             )
         logger.info(
             "Initialized moderation mbert detector "
-            f"(hybrid mode, confidence_threshold={confidence_threshold})"
+            f"(hybrid mode, confidence_threshold={confidence_threshold}, "
+            f"model={model}, base_url={self.base_url})"
         )
 
     # ------------------------------------------------------------------
@@ -513,23 +542,25 @@ class ModerationMbertHybrid(MBertToxicContentModel):
     ) -> DetectionResult:
         """Run Safeguard on one low-confidence item, with graceful fallback."""
         query_string = self._truncate_if_needed(dome_input.query_string)
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": MODERATION_SAFEGUARD_SYSTEM_PROMPT},
+                {"role": "user", "content": query_string},
+            ],
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+        if self.reasoning_effort is not None:
+            payload["reasoning_effort"] = self.reasoning_effort
         try:
             resp = await client.post(
-                GROQ_CHAT_COMPLETIONS_URL,
+                self.chat_completions_url,
                 headers={
-                    "Authorization": f"Bearer {self.groq_api_key}",
+                    "Authorization": f"Bearer {self.api_key}",
                     "Content-Type": "application/json",
                 },
-                json={
-                    "model": self.groq_model,
-                    "messages": [
-                        {"role": "system", "content": MODERATION_SAFEGUARD_SYSTEM_PROMPT},
-                        {"role": "user", "content": query_string},
-                    ],
-                    "temperature": self.temperature,
-                    "max_tokens": self.max_tokens,
-                    "reasoning_effort": "low",
-                },
+                json=payload,
             )
             resp.raise_for_status()
             content = (
@@ -575,7 +606,7 @@ class ModerationMbertHybrid(MBertToxicContentModel):
             )
 
         # Low confidence -> escalate to Safeguard if we have a key.
-        if not self.groq_api_key:
+        if not self.api_key:
             flagged = score >= self.score_threshold
             return flagged, self._fast_payload(
                 dome_input, score, prediction, stage="fast-fallback"
@@ -618,7 +649,7 @@ class ModerationMbertHybrid(MBertToxicContentModel):
                     flagged,
                     self._fast_payload(dome_input, score, prediction, stage="fast"),
                 )
-            elif not self.groq_api_key:
+            elif not self.api_key:
                 flagged = score >= self.score_threshold
                 results[idx] = (
                     flagged,

--- a/vijil_dome/tests/detectors/test_moderations_detectors.py
+++ b/vijil_dome/tests/detectors/test_moderations_detectors.py
@@ -241,7 +241,7 @@ async def test_stereotype_eeoc_safeguard_handles_api_error():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         STEREOTYPE_EEOC_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     class _BoomClient:
@@ -268,7 +268,7 @@ async def test_stereotype_eeoc_safeguard_parses_unsafe_verdict():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         STEREOTYPE_EEOC_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     fake_response = AsyncMock()
@@ -503,7 +503,7 @@ async def test_stereotype_eeoc_safeguard_inherits_detection_method():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         STEREOTYPE_EEOC_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
     assert isinstance(detector, DetectionMethod)
     assert detector.max_batch_concurrency == 5
@@ -519,7 +519,7 @@ async def test_stereotype_eeoc_safeguard_truncates_oversize_input():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         STEREOTYPE_EEOC_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
         max_input_chars=100,
     )
 
@@ -556,7 +556,7 @@ async def test_stereotype_eeoc_safeguard_disable_truncation_with_none():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         STEREOTYPE_EEOC_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
         max_input_chars=None,
     )
     assert detector.max_input_chars is None
@@ -574,7 +574,7 @@ async def test_stereotype_eeoc_safeguard_detect_batch_returns_all_results():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         STEREOTYPE_EEOC_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     fake_response = AsyncMock()
@@ -670,7 +670,7 @@ async def test_moderation_mbert_safeguard_inherits_detection_method():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         MODERATION_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
     assert isinstance(detector, DetectionMethod)
     assert detector.max_batch_concurrency == 5
@@ -682,7 +682,7 @@ async def test_moderation_mbert_safeguard_handles_api_error():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         MODERATION_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     class _BoomClient:
@@ -709,7 +709,7 @@ async def test_moderation_mbert_safeguard_parses_unsafe_verdict():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         MODERATION_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     fake_response = AsyncMock()
@@ -745,7 +745,7 @@ async def test_moderation_mbert_safeguard_parses_safe_verdict():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         MODERATION_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     fake_response = AsyncMock()
@@ -777,7 +777,7 @@ async def test_moderation_mbert_safeguard_truncates_oversize_input():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         MODERATION_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
         max_input_chars=100,
     )
 
@@ -811,7 +811,7 @@ async def test_moderation_mbert_safeguard_detect_batch_returns_all_results():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Moderation,
         MODERATION_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     fake_response = AsyncMock()

--- a/vijil_dome/tests/detectors/test_security_detectors.py
+++ b/vijil_dome/tests/detectors/test_security_detectors.py
@@ -181,7 +181,7 @@ async def test_pi_mbert_safeguard_inherits_detection_method():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Security,
         PI_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
     assert isinstance(detector, DetectionMethod)
     assert detector.max_batch_concurrency == 5
@@ -193,7 +193,7 @@ async def test_pi_mbert_safeguard_handles_api_error():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Security,
         PI_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     class _BoomClient:
@@ -220,7 +220,7 @@ async def test_pi_mbert_safeguard_parses_unsafe_verdict():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Security,
         PI_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     fake_response = AsyncMock()
@@ -256,7 +256,7 @@ async def test_pi_mbert_safeguard_parses_safe_verdict():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Security,
         PI_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     fake_response = AsyncMock()
@@ -288,7 +288,7 @@ async def test_pi_mbert_safeguard_truncates_oversize_input():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Security,
         PI_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
         max_input_chars=100,
     )
 
@@ -322,7 +322,7 @@ async def test_pi_mbert_safeguard_detect_batch_returns_all_results():
     detector = DetectionFactory.get_detector(
         DetectionCategory.Security,
         PI_MBERT_SAFEGUARD,
-        groq_api_key="dummy-key-for-test",
+        api_key="dummy-key-for-test",
     )
 
     fake_response = AsyncMock()


### PR DESCRIPTION
Exposes base url, api key name, and model name for safeguard/hybrid detectors to use with other inference stacks