### PR TITLE
Support remote vijil inference endpoints and make torch optional

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -831,10 +831,10 @@ test-randomorder = ["pytest-randomly"]
 name = "cuda-bindings"
 version = "12.9.4"
 description = "Python bindings for CUDA"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a022c96b8bd847e8dc0675523431149a4c3e872f440e3002213dbb9e08f0331a"},
     {file = "cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5"},
@@ -873,10 +873,10 @@ test = ["cython (>=3.1,<3.2)", "numpy (>=1.21.1)", "pyglet (>=2.1.9)", "pytest (
 name = "cuda-pathfinder"
 version = "1.4.2"
 description = "Pathfinder for CUDA components"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "cuda_pathfinder-1.4.2-py3-none-any.whl", hash = "sha256:eb354abc20278f8609dc5b666a24648655bef5613c6dfe78a238a6fd95566754"},
 ]
@@ -2179,9 +2179,10 @@ files = [
 name = "joblib"
 version = "1.5.3"
 description = "Lightweight pipelining with Python functions"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713"},
     {file = "joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3"},
@@ -2511,9 +2512,10 @@ files = [
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
     {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
@@ -2772,9 +2774,10 @@ files = [
 name = "networkx"
 version = "3.6.1"
 description = "Python package for creating and manipulating graphs and networks"
-optional = false
+optional = true
 python-versions = "!=3.14.1,>=3.11"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
     {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
@@ -2877,10 +2880,10 @@ files = [
 name = "nvidia-cublas-cu12"
 version = "12.8.4.1"
 description = "CUBLAS native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0"},
     {file = "nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142"},
@@ -2891,10 +2894,10 @@ files = [
 name = "nvidia-cuda-cupti-cu12"
 version = "12.8.90"
 description = "CUDA profiling tools runtime libs."
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed"},
     {file = "nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182"},
@@ -2905,10 +2908,10 @@ files = [
 name = "nvidia-cuda-nvrtc-cu12"
 version = "12.8.93"
 description = "NVRTC native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994"},
     {file = "nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8"},
@@ -2919,10 +2922,10 @@ files = [
 name = "nvidia-cuda-runtime-cu12"
 version = "12.8.90"
 description = "CUDA Runtime native Libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d"},
     {file = "nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90"},
@@ -2933,10 +2936,10 @@ files = [
 name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 description = "cuDNN runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8"},
     {file = "nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8"},
@@ -2950,10 +2953,10 @@ nvidia-cublas-cu12 = "*"
 name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 description = "CUFFT native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a"},
     {file = "nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74"},
@@ -2967,10 +2970,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cufile-cu12"
 version = "1.13.1.3"
 description = "cuFile GPUDirect libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc"},
     {file = "nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a"},
@@ -2980,10 +2983,10 @@ files = [
 name = "nvidia-curand-cu12"
 version = "10.3.9.90"
 description = "CURAND native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd"},
     {file = "nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9"},
@@ -2994,10 +2997,10 @@ files = [
 name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 description = "CUDA solver native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0"},
     {file = "nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450"},
@@ -3013,10 +3016,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 description = "CUSPARSE native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc"},
     {file = "nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b"},
@@ -3030,10 +3033,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cusparselt-cu12"
 version = "0.7.1"
 description = "NVIDIA cuSPARSELt"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5"},
     {file = "nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623"},
@@ -3044,10 +3047,10 @@ files = [
 name = "nvidia-nccl-cu12"
 version = "2.27.5"
 description = "NVIDIA Collective Communication Library (NCCL) Runtime"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a"},
     {file = "nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457"},
@@ -3057,10 +3060,10 @@ files = [
 name = "nvidia-nvjitlink-cu12"
 version = "12.8.93"
 description = "Nvidia JIT LTO Library"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88"},
     {file = "nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7"},
@@ -3071,10 +3074,10 @@ files = [
 name = "nvidia-nvshmem-cu12"
 version = "3.4.5"
 description = "NVSHMEM creates a global address space that provides efficient and scalable communication for NVIDIA GPU clusters."
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15"},
     {file = "nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd"},
@@ -3084,10 +3087,10 @@ files = [
 name = "nvidia-nvtx-cu12"
 version = "12.8.90"
 description = "NVIDIA Tools Extension"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615"},
     {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f"},
@@ -4830,9 +4833,10 @@ crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 name = "safetensors"
 version = "0.7.0"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517"},
     {file = "safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57"},
@@ -4877,9 +4881,10 @@ torch = ["packaging", "safetensors[numpy]", "torch (>=1.10)"]
 name = "scikit-learn"
 version = "1.8.0"
 description = "A set of python modules for machine learning and data mining"
-optional = false
+optional = true
 python-versions = ">=3.11"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da"},
     {file = "scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1"},
@@ -5035,9 +5040,10 @@ jeepney = ">=0.6"
 name = "sentence-transformers"
 version = "5.2.3"
 description = "Embeddings, Retrieval, and Reranking"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "sentence_transformers-5.2.3-py3-none-any.whl", hash = "sha256:6437c62d4112b615ddebda362dfc16a4308d604c5b68125ed586e3e95d5b2e30"},
     {file = "sentence_transformers-5.2.3.tar.gz", hash = "sha256:3cd3044e1f3fe859b6a1b66336aac502eaae5d3dd7d5c8fc237f37fbf58137c7"},
@@ -5422,9 +5428,10 @@ writer = ["writer-sdk (>=2.2.0,<3.0.0)"]
 name = "sympy"
 version = "1.14.0"
 description = "Computer algebra system (CAS) in Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"},
     {file = "sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"},
@@ -5530,9 +5537,10 @@ torch = ["torch (>=1.6.0)"]
 name = "threadpoolctl"
 version = "3.6.0"
 description = "threadpoolctl"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb"},
     {file = "threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e"},
@@ -5683,9 +5691,10 @@ files = [
 name = "torch"
 version = "2.10.0"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d"},
     {file = "torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444"},
@@ -5774,9 +5783,10 @@ telegram = ["requests"]
 name = "transformers"
 version = "4.53.3"
 description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
-optional = false
+optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "transformers-4.53.3-py3-none-any.whl", hash = "sha256:5aba81c92095806b6baf12df35d756cf23b66c356975fb2a7fa9e536138d7c75"},
     {file = "transformers-4.53.3.tar.gz", hash = "sha256:b2eda1a261de79b78b97f7888fe2005fc0c3fabf5dad33d52cc02983f9f675d8"},
@@ -5847,10 +5857,10 @@ vision = ["Pillow (>=10.0.1,<=15.0)"]
 name = "triton"
 version = "3.6.0"
 description = "A language and compiler for custom Deep Learning operations"
-optional = false
+optional = true
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
+markers = "platform_machine == \"x86_64\" and extra == \"local\" and platform_system == \"Linux\""
 files = [
     {file = "triton-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c723cfb12f6842a0ae94ac307dba7e7a44741d720a40cf0e270ed4a4e3be781"},
     {file = "triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea"},
@@ -6544,6 +6554,7 @@ type = ["pytest-mypy"]
 embeddings = ["annoy", "faiss-cpu"]
 google = ["google-api-python-client"]
 langchain = []
+local = ["sentence-transformers", "torch", "transformers"]
 mcp = ["fastmcp", "mcp"]
 opentelemetry = ["opentelemetry-api", "opentelemetry-exporter-gcp-monitoring", "opentelemetry-exporter-gcp-trace", "opentelemetry-exporter-otlp", "opentelemetry-exporter-otlp-proto-common", "opentelemetry-exporter-otlp-proto-grpc", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-instrumentation", "opentelemetry-instrumentation-asyncio", "opentelemetry-instrumentation-logging", "opentelemetry-instrumentation-threading", "opentelemetry-propagator-gcp", "opentelemetry-proto", "opentelemetry-resourcedetector-gcp", "opentelemetry-sdk", "opentelemetry-semantic-conventions"]
 s3 = ["boto3"]
@@ -6553,4 +6564,4 @@ test = ["pytest", "pytest-asyncio"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "eecb605f2408e089e802decbf6daf9c5e6b86fcea7824a7978f8b147dc26586e"
+content-hash = "e92016c9791784458f778983a87c1aa4c26ddc97c7cd56c0630b8fe9c866093e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ python = ">=3.11,<3.14"
 
 openai = ">=1.93.2"
 pydantic = "^2.11.7"
-torch = "^2.8.0"
-transformers = "^4.53.1"
-sentence-transformers = "^5.0.0"
+torch = {version = "^2.8.0", optional = true}
+transformers = {version = "^4.53.1", optional = true}
+sentence-transformers = {version = "^5.0.0", optional = true}
 numpy = "^2.1.0" # "^1.26.4"
 scipy = "^1.16.0"
 pandas = "^2.3.1"
@@ -88,6 +88,7 @@ opentelemetry = [
     "opentelemetry-sdk",
     "opentelemetry-semantic-conventions",
 ]
+local = ["torch", "transformers", "sentence-transformers"]
 embeddings = [ "annoy", "faiss-cpu", ]
 langchain = [ ]  # no langchain usage detected — you can add back if needed
 google = [ "google-api-python-client", ]

--- a/vijil_dome/detectors/__init__.py
+++ b/vijil_dome/detectors/__init__.py
@@ -37,6 +37,7 @@ MODERATION_DEBERTA = "moderation-deberta"
 MODERATION_MBERT = "moderation-mbert"
 MODERATION_MBERT_SAFEGUARD = "moderation-mbert-safeguard"
 MODERATION_MBERT_HYBRID = "moderation-mbert-hybrid"
+MODERATION_MBERT_REMOTE = "moderation-mbert-remote"
 
 PRIVACY_PRESIDIO = "privacy-presidio"
 DETECT_SECRETS = "detect-secrets"
@@ -48,6 +49,7 @@ PI_DEBERTA_FINETUNED_11122024 = "prompt-injection-deberta-finetuned-11122024"
 PI_MBERT = "prompt-injection-mbert"
 PI_MBERT_SAFEGUARD = "prompt-injection-mbert-safeguard"
 PI_MBERT_HYBRID = "prompt-injection-mbert-hybrid"
+PI_MBERT_REMOTE = "prompt-injection-mbert-remote"
 SECURITY_LLM = "security-llm"
 SECURITY_EMBEDDINGS = "security-embeddings"
 SECURITY_PROMPTGUARD = "security-promptguard"
@@ -65,6 +67,7 @@ POLICY_SECTIONS = "policy-sections"
 STEREOTYPE_EEOC_FAST = "stereotype-eeoc-fast"
 STEREOTYPE_EEOC_SAFEGUARD = "stereotype-eeoc-safeguard"
 STEREOTYPE_EEOC_HYBRID = "stereotype-eeoc-hybrid"
+STEREOTYPE_EEOC_REMOTE = "stereotype-eeoc-remote"
 
 # Define types for detection results and data
 DetectorType = Dict["type", str]

--- a/vijil_dome/detectors/methods/__init__.py
+++ b/vijil_dome/detectors/methods/__init__.py
@@ -14,26 +14,41 @@
 #
 # vijil and vijil-dome are trademarks owned by Vijil Inc.
 
-# Exposing all method files for ease of import
+# Exposing all method files for ease of import.
+# Modules that support both local (torch) and remote (no torch) modes
+# are always importable. Torch-only modules are gated behind a check
+# so that ``pip install vijil-dome`` (without the ``local`` extra)
+# still loads the remote / API-only detectors.
 __all__ = [
-    "factcheck_roberta",
     "flashtext_kw_banlist",
-    "hhem_hallucination",
-    "jb_perplexity_heuristics",
     "llm_models",
     "openai_models",
-    "pi_hf_deberta",
-    "pi_hf_mbert",
     "pii_presidio",
-    "toxicity_deberta",
-    "toxicity_mbert",
-    "embedding_models",
     "secret_detector",
     "encoding_heuristics",
     "gpt_oss_safeguard_policy",
     "policy_sections_detector",
+    # These three have lazy torch imports and work without torch
+    # (remote + safeguard modes stay available).
+    "pi_hf_mbert",
+    "toxicity_mbert",
     "stereotype_eeoc",
 ]
+
+# Modules that require torch for all functionality.
+try:
+    import torch  # noqa: F401
+
+    __all__.extend([
+        "factcheck_roberta",
+        "hhem_hallucination",
+        "jb_perplexity_heuristics",
+        "pi_hf_deberta",
+        "toxicity_deberta",
+        "embedding_models",
+    ])
+except ImportError:
+    pass
 
 try:
     import googleapiclient  # noqa: F401

--- a/vijil_dome/detectors/methods/pi_hf_mbert.py
+++ b/vijil_dome/detectors/methods/pi_hf_mbert.py
@@ -28,13 +28,19 @@ import os
 from typing import Dict, List, Optional, Tuple, Union
 
 import httpx
-import torch
-from transformers import pipeline
+
+try:
+    import torch
+    from transformers import pipeline
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
 
 from vijil_dome.detectors import (
     PI_MBERT,
     PI_MBERT_SAFEGUARD,
     PI_MBERT_HYBRID,
+    PI_MBERT_REMOTE,
     register_method,
     DetectionCategory,
     DetectionMethod,
@@ -74,6 +80,9 @@ DEFAULT_SAFEGUARD_API_KEY_NAME = "GROQ_API_KEY"
 DEFAULT_SAFEGUARD_BASE_URL = "https://api.groq.com/openai/v1"
 DEFAULT_SAFEGUARD_MODEL = "openai/gpt-oss-safeguard-20b"
 
+# Default model name on Vijil's inference endpoint (matches HuggingFace).
+DEFAULT_VIJIL_INFERENCE_PI_MODEL = "vijil/vijil_dome_prompt_injection_detection"
+
 
 # ----------------------------------------------------------------------
 # Fast mode (original detector, unchanged interface)
@@ -108,6 +117,11 @@ class MBertPromptInjectionModel(HFBaseModel):
             Step size in tokens between sliding windows for inputs that
             exceed *max_length*. Default 4096 (half of *max_length*).
         """
+        if not _HAS_TORCH:
+            raise ImportError(
+                f"{PI_MBERT} requires 'torch' and 'transformers'. "
+                "Install with: pip install vijil-dome[local]"
+            )
         try:
             super().__init__(
                 model_name="vijil/vijil_dome_prompt_injection_detection",
@@ -420,6 +434,83 @@ class PImbertSafeguard(DetectionMethod):
 
 
 # ----------------------------------------------------------------------
+# Remote mode (Vijil inference endpoint, no local model)
+# ----------------------------------------------------------------------
+
+
+@register_method(DetectionCategory.Security, PI_MBERT_REMOTE)
+class MBertPromptInjectionRemote(DetectionMethod):
+    """Prompt injection detection via Vijil's remote inference service.
+
+    Calls Vijil's hosted ModernBERT endpoint — no local model, no torch.
+    Suitable for lightweight deployments where the inference server is
+    co-located or latency is acceptable.
+
+    This detector only works with Vijil's inference endpoint — do not
+    point it at arbitrary OpenAI-compatible services.
+    """
+
+    def __init__(
+        self,
+        vijil_inference_url: str,
+        vijil_inference_model: Optional[str] = None,
+        vijil_inference_api_key: Optional[str] = None,
+        score_threshold: float = 0.5,
+        timeout_seconds: float = 10.0,
+    ):
+        from vijil_dome.detectors.utils.vijil_inference import VijilInferenceClient
+
+        self.score_threshold = score_threshold
+        self.response_string = f"Method:{PI_MBERT_REMOTE}"
+        self.run_in_executor = False
+        self._vijil_client = VijilInferenceClient(
+            base_url=vijil_inference_url,
+            model=vijil_inference_model or DEFAULT_VIJIL_INFERENCE_PI_MODEL,
+            api_key=vijil_inference_api_key,
+            timeout_seconds=timeout_seconds,
+        )
+        logger.info(
+            "Initialized PI mbert detector (remote mode, "
+            f"model={self._vijil_client.model}, url={self._vijil_client.base_url})"
+        )
+
+    async def detect(self, dome_input: DomePayload) -> DetectionResult:
+        dome_input = DomePayload.coerce(dome_input)
+        query_string = dome_input.query_string
+        logger.info("Detecting prompt injection using Vijil remote inference...")
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._vijil_client.timeout_seconds
+            ) as client:
+                score = await self._vijil_client.classify(client, query_string)
+            flagged = score >= self.score_threshold
+            return flagged, {
+                "type": type(self),
+                "detector": PI_MBERT_REMOTE,
+                "score": score,
+                "label": "injection" if flagged else "safe",
+                "response_string": self.response_string if flagged else query_string,
+            }
+        except Exception as e:
+            logger.error(f"Vijil remote inference failed: {e}")
+            return False, {
+                "type": type(self),
+                "detector": PI_MBERT_REMOTE,
+                "score": 0.0,
+                "label": "error",
+                "error": str(e),
+                "response_string": query_string,
+            }
+
+    async def detect_batch(
+        self, inputs: List[Union[str, DomePayload]]
+    ) -> BatchDetectionResult:
+        return await self._gather_with_concurrency(
+            [self.detect(DomePayload.coerce(item)) for item in inputs]
+        )
+
+
+# ----------------------------------------------------------------------
 # Hybrid mode (fast + Safeguard escalation)
 # ----------------------------------------------------------------------
 
@@ -427,13 +518,19 @@ class PImbertSafeguard(DetectionMethod):
 @register_method(DetectionCategory.Security, PI_MBERT_HYBRID)
 class PImbertHybrid(MBertPromptInjectionModel):
     """
-    Hybrid prompt injection detection: ModernBERT first, Safeguard on
-    low-confidence. ~5ms average, near-100% accuracy, API cost only on
-    uncertain examples.
+    Hybrid prompt injection detection: fast stage first (local ModernBERT
+    or Vijil remote inference), Safeguard on low-confidence.
+
+    When ``vijil_inference_url`` is provided the fast stage calls Vijil's
+    hosted inference endpoint instead of loading ModernBERT locally,
+    eliminating the torch/transformers dependency for the fast stage.
     """
 
     def __init__(
         self,
+        vijil_inference_url: Optional[str] = None,
+        vijil_inference_model: Optional[str] = None,
+        vijil_inference_api_key: Optional[str] = None,
         confidence_threshold: float = 0.85,
         api_key: Optional[str] = None,
         api_key_name: str = DEFAULT_SAFEGUARD_API_KEY_NAME,
@@ -446,7 +543,19 @@ class PImbertHybrid(MBertPromptInjectionModel):
         max_input_chars: Optional[int] = DEFAULT_SAFEGUARD_MAX_INPUT_CHARS,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        self._use_vijil_inference = vijil_inference_url is not None
+
+        if self._use_vijil_inference:
+            from vijil_dome.detectors.utils.vijil_inference import VijilInferenceClient
+            self.score_threshold = kwargs.get("score_threshold", 0.5)
+            self._vijil_client = VijilInferenceClient(
+                base_url=vijil_inference_url,
+                model=vijil_inference_model or DEFAULT_VIJIL_INFERENCE_PI_MODEL,
+                api_key=vijil_inference_api_key,
+            )
+        else:
+            super().__init__(**kwargs)
+
         self.confidence_threshold = confidence_threshold
         self.api_key_name = api_key_name
         self.api_key = api_key or os.environ.get(api_key_name, "")
@@ -465,10 +574,16 @@ class PImbertHybrid(MBertPromptInjectionModel):
             logger.warning(
                 f"{api_key_name} not set \u2014 {PI_MBERT_HYBRID} will fall back to fast-only"
             )
+        fast_mode = (
+            f"vijil-inference ({self._vijil_client.base_url})"
+            if self._use_vijil_inference
+            else "local"
+        )
         logger.info(
             "Initialized PI mbert detector "
-            f"(hybrid mode, confidence_threshold={confidence_threshold}, "
-            f"model={model}, base_url={self.base_url})"
+            f"(hybrid mode, fast={fast_mode}, "
+            f"confidence_threshold={confidence_threshold}, "
+            f"safeguard_model={model}, safeguard_url={self.base_url})"
         )
 
     # ------------------------------------------------------------------
@@ -579,15 +694,71 @@ class PImbertHybrid(MBertPromptInjectionModel):
     # Public detection interface
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # Vijil remote inference helpers (hybrid fast stage)
+    # ------------------------------------------------------------------
+
+    async def _classify_vijil(
+        self, client: httpx.AsyncClient, dome_input: DomePayload
+    ) -> Tuple[float, dict]:
+        """Classify a single input via Vijil's remote inference endpoint."""
+        score = await self._vijil_client.classify(client, dome_input.query_string)
+        return score, {}
+
+    async def _classify_batch_vijil(
+        self, dome_inputs: List[DomePayload]
+    ) -> List[Tuple[float, dict]]:
+        """Classify a batch via Vijil's remote inference endpoint."""
+        async with httpx.AsyncClient(
+            timeout=self._vijil_client.timeout_seconds
+        ) as client:
+            semaphore = asyncio.Semaphore(self.max_batch_concurrency)
+
+            async def _one(di: DomePayload) -> Tuple[float, dict]:
+                async with semaphore:
+                    try:
+                        score = await self._vijil_client.classify(
+                            client, di.query_string
+                        )
+                        return score, {}
+                    except Exception as e:
+                        logger.error(f"Vijil inference batch item failed: {e}")
+                        return 0.0, {"error": str(e)}
+
+            return list(await asyncio.gather(*(_one(di) for di in dome_inputs)))
+
+    # ------------------------------------------------------------------
+    # Public detection interface
+    # ------------------------------------------------------------------
+
     async def detect(self, dome_input: DomePayload) -> DetectionResult:
         dome_input = DomePayload.coerce(dome_input)
         logger.info("Detecting prompt injection using hybrid mode...")
 
-        # Stage 1: Fast ModernBERT classification in a thread executor
-        loop = asyncio.get_running_loop()
-        score, prediction = await loop.run_in_executor(
-            None, self._classify, dome_input
-        )
+        # Stage 1: fast classification (remote or local)
+        if self._use_vijil_inference:
+            try:
+                async with httpx.AsyncClient(
+                    timeout=self._vijil_client.timeout_seconds
+                ) as client:
+                    score, prediction = await self._classify_vijil(client, dome_input)
+            except Exception as e:
+                logger.error(f"Vijil inference failed in hybrid fast stage: {e}")
+                return False, {
+                    "type": type(self),
+                    "detector": PI_MBERT_HYBRID,
+                    "stage": "vijil-inference-error",
+                    "score": 0.0,
+                    "label": "error",
+                    "error": str(e),
+                    "response_string": dome_input.query_string,
+                }
+        else:
+            loop = asyncio.get_running_loop()
+            score, prediction = await loop.run_in_executor(
+                None, self._classify, dome_input
+            )
+
         confidence = max(score, 1.0 - score)
         logger.debug(
             "pi-mbert-hybrid fast-stage prediction=%s score=%.3f",
@@ -621,17 +792,19 @@ class PImbertHybrid(MBertPromptInjectionModel):
     ) -> BatchDetectionResult:
         """Batched hybrid detection.
 
-        Runs the fast ModernBERT stage on the whole batch in one pipeline
-        call, then escalates any low-confidence items to Safeguard
-        concurrently via ``asyncio.gather``.
+        Runs the fast stage on the whole batch (remote or local), then
+        escalates any low-confidence items to Safeguard concurrently.
         """
         dome_inputs = [DomePayload.coerce(x) for x in inputs]
 
-        # Stage 1: batched fast classification in a thread executor.
-        loop = asyncio.get_running_loop()
-        scored = await loop.run_in_executor(
-            None, self._classify_batch, dome_inputs
-        )
+        # Stage 1: batched fast classification (remote or local).
+        if self._use_vijil_inference:
+            scored = await self._classify_batch_vijil(dome_inputs)
+        else:
+            loop = asyncio.get_running_loop()
+            scored = await loop.run_in_executor(
+                None, self._classify_batch, dome_inputs
+            )
 
         # Partition into "confident enough" vs "escalate".
         results: List[Optional[DetectionResult]] = [None] * len(dome_inputs)

--- a/vijil_dome/detectors/methods/pi_hf_mbert.py
+++ b/vijil_dome/detectors/methods/pi_hf_mbert.py
@@ -547,6 +547,7 @@ class PImbertHybrid(MBertPromptInjectionModel):
 
         if self._use_vijil_inference:
             from vijil_dome.detectors.utils.vijil_inference import VijilInferenceClient
+            assert vijil_inference_url is not None
             self.score_threshold = kwargs.get("score_threshold", 0.5)
             self._vijil_client = VijilInferenceClient(
                 base_url=vijil_inference_url,

--- a/vijil_dome/detectors/methods/stereotype_eeoc.py
+++ b/vijil_dome/detectors/methods/stereotype_eeoc.py
@@ -69,13 +69,19 @@ import os
 from typing import Dict, List, Optional, Tuple, Union
 
 import httpx
-import torch
-from transformers import pipeline
+
+try:
+    import torch
+    from transformers import pipeline
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
 
 from vijil_dome.detectors import (
     STEREOTYPE_EEOC_FAST,
     STEREOTYPE_EEOC_SAFEGUARD,
     STEREOTYPE_EEOC_HYBRID,
+    STEREOTYPE_EEOC_REMOTE,
     register_method,
     DetectionCategory,
     DetectionMethod,
@@ -128,6 +134,9 @@ DEFAULT_SAFEGUARD_API_KEY_NAME = "GROQ_API_KEY"
 DEFAULT_SAFEGUARD_BASE_URL = "https://api.groq.com/openai/v1"
 DEFAULT_SAFEGUARD_MODEL = "openai/gpt-oss-safeguard-20b"
 
+# Default model name on Vijil's inference endpoint (matches HuggingFace).
+DEFAULT_VIJIL_INFERENCE_STEREOTYPE_MODEL = "vijil/stereotype-eeoc-detector"
+
 
 class StereotypeEEOCBase(HFBaseModel):
     """Base class for EEOC stereotype detection using ModernBERT."""
@@ -147,6 +156,11 @@ class StereotypeEEOCBase(HFBaseModel):
         score_threshold: float = 0.5,
         max_length: int = 512,
     ):
+        if not _HAS_TORCH:
+            raise ImportError(
+                f"{STEREOTYPE_EEOC_FAST} requires 'torch' and 'transformers'. "
+                "Install with: pip install vijil-dome[local]"
+            )
         try:
             super().__init__(
                 model_name=model_name,
@@ -573,6 +587,83 @@ class StereotypeEEOCSafeguard(DetectionMethod):
 
 
 # ----------------------------------------------------------------------
+# Remote mode (Vijil inference endpoint, no local model)
+# ----------------------------------------------------------------------
+
+
+@register_method(DetectionCategory.Moderation, STEREOTYPE_EEOC_REMOTE)
+class StereotypeEEOCRemote(DetectionMethod):
+    """EEOC stereotype detection via Vijil's remote inference service.
+
+    Calls Vijil's hosted ModernBERT endpoint — no local model, no torch.
+    Suitable for lightweight deployments where the inference server is
+    co-located or latency is acceptable.
+
+    This detector only works with Vijil's inference endpoint — do not
+    point it at arbitrary OpenAI-compatible services.
+    """
+
+    def __init__(
+        self,
+        vijil_inference_url: str,
+        vijil_inference_model: Optional[str] = None,
+        vijil_inference_api_key: Optional[str] = None,
+        score_threshold: float = 0.5,
+        timeout_seconds: float = 10.0,
+    ):
+        from vijil_dome.detectors.utils.vijil_inference import VijilInferenceClient
+
+        self.score_threshold = score_threshold
+        self.response_string = f"Method:{STEREOTYPE_EEOC_REMOTE}"
+        self.run_in_executor = False
+        self._vijil_client = VijilInferenceClient(
+            base_url=vijil_inference_url,
+            model=vijil_inference_model or DEFAULT_VIJIL_INFERENCE_STEREOTYPE_MODEL,
+            api_key=vijil_inference_api_key,
+            timeout_seconds=timeout_seconds,
+        )
+        logger.info(
+            "Initialized EEOC stereotype detector (remote mode, "
+            f"model={self._vijil_client.model}, url={self._vijil_client.base_url})"
+        )
+
+    async def detect(self, dome_input: DomePayload) -> DetectionResult:
+        dome_input = DomePayload.coerce(dome_input)
+        query_string = dome_input.query_string
+        logger.info("Detecting EEOC stereotype using Vijil remote inference...")
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._vijil_client.timeout_seconds
+            ) as client:
+                score = await self._vijil_client.classify(client, query_string)
+            flagged = score >= self.score_threshold
+            return flagged, {
+                "type": type(self),
+                "detector": STEREOTYPE_EEOC_REMOTE,
+                "score": score,
+                "label": "stereotyped" if flagged else "neutral",
+                "response_string": self.response_string if flagged else query_string,
+            }
+        except Exception as e:
+            logger.error(f"Vijil remote inference failed: {e}")
+            return False, {
+                "type": type(self),
+                "detector": STEREOTYPE_EEOC_REMOTE,
+                "score": 0.0,
+                "label": "error",
+                "error": str(e),
+                "response_string": query_string,
+            }
+
+    async def detect_batch(
+        self, inputs: List[Union[str, DomePayload]]
+    ) -> BatchDetectionResult:
+        return await self._gather_with_concurrency(
+            [self.detect(DomePayload.coerce(item)) for item in inputs]
+        )
+
+
+# ----------------------------------------------------------------------
 # Hybrid mode (fast + Safeguard escalation)
 # ----------------------------------------------------------------------
 
@@ -580,13 +671,19 @@ class StereotypeEEOCSafeguard(DetectionMethod):
 @register_method(DetectionCategory.Moderation, STEREOTYPE_EEOC_HYBRID)
 class StereotypeEEOCHybrid(StereotypeEEOCBase):
     """
-    Hybrid EEOC stereotype detection: ModernBERT first, Safeguard on
-    low-confidence. ~5ms average, near-100% accuracy, API cost only on
-    uncertain examples.
+    Hybrid EEOC stereotype detection: fast stage first (local ModernBERT
+    or Vijil remote inference), Safeguard on low-confidence.
+
+    When ``vijil_inference_url`` is provided the fast stage calls Vijil's
+    hosted inference endpoint instead of loading ModernBERT locally,
+    eliminating the torch/transformers dependency for the fast stage.
     """
 
     def __init__(
         self,
+        vijil_inference_url: Optional[str] = None,
+        vijil_inference_model: Optional[str] = None,
+        vijil_inference_api_key: Optional[str] = None,
         confidence_threshold: float = 0.85,
         api_key: Optional[str] = None,
         api_key_name: str = DEFAULT_SAFEGUARD_API_KEY_NAME,
@@ -599,7 +696,19 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
         max_input_chars: Optional[int] = DEFAULT_SAFEGUARD_MAX_INPUT_CHARS,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        self._use_vijil_inference = vijil_inference_url is not None
+
+        if self._use_vijil_inference:
+            from vijil_dome.detectors.utils.vijil_inference import VijilInferenceClient
+            self.score_threshold = kwargs.get("score_threshold", 0.5)
+            self._vijil_client = VijilInferenceClient(
+                base_url=vijil_inference_url,
+                model=vijil_inference_model or DEFAULT_VIJIL_INFERENCE_STEREOTYPE_MODEL,
+                api_key=vijil_inference_api_key,
+            )
+        else:
+            super().__init__(**kwargs)
+
         self.confidence_threshold = confidence_threshold
         self.api_key_name = api_key_name
         self.api_key = api_key or os.environ.get(api_key_name, "")
@@ -618,10 +727,16 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
             logger.warning(
                 f"{api_key_name} not set — {STEREOTYPE_EEOC_HYBRID} will fall back to fast-only"
             )
+        fast_mode = (
+            f"vijil-inference ({self._vijil_client.base_url})"
+            if self._use_vijil_inference
+            else "local"
+        )
         logger.info(
             "Initialized EEOC stereotype detector "
-            f"(hybrid mode, confidence_threshold={confidence_threshold}, "
-            f"model={model}, base_url={self.base_url})"
+            f"(hybrid mode, fast={fast_mode}, "
+            f"confidence_threshold={confidence_threshold}, "
+            f"safeguard_model={model}, safeguard_url={self.base_url})"
         )
 
     # Fast-stage payload builder — shared between detect and detect_batch.
@@ -724,16 +839,71 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
             payload["error"] = str(e)
             return fast_score >= self.score_threshold, payload
 
+    # ------------------------------------------------------------------
+    # Vijil remote inference helpers (hybrid fast stage)
+    # ------------------------------------------------------------------
+
+    async def _classify_vijil(
+        self, client: httpx.AsyncClient, dome_input: DomePayload
+    ) -> Tuple[float, dict]:
+        """Classify a single input via Vijil's remote inference endpoint."""
+        score = await self._vijil_client.classify(client, dome_input.query_string)
+        return score, {}
+
+    async def _classify_batch_vijil(
+        self, dome_inputs: List[DomePayload]
+    ) -> List[Tuple[float, dict]]:
+        """Classify a batch via Vijil's remote inference endpoint."""
+        async with httpx.AsyncClient(
+            timeout=self._vijil_client.timeout_seconds
+        ) as client:
+            semaphore = asyncio.Semaphore(self.max_batch_concurrency)
+
+            async def _one(di: DomePayload) -> Tuple[float, dict]:
+                async with semaphore:
+                    try:
+                        score = await self._vijil_client.classify(
+                            client, di.query_string
+                        )
+                        return score, {}
+                    except Exception as e:
+                        logger.error(f"Vijil inference batch item failed: {e}")
+                        return 0.0, {"error": str(e)}
+
+            return list(await asyncio.gather(*(_one(di) for di in dome_inputs)))
+
+    # ------------------------------------------------------------------
+    # Public detection interface
+    # ------------------------------------------------------------------
+
     async def detect(self, dome_input: DomePayload) -> DetectionResult:
         dome_input = DomePayload.coerce(dome_input)
         logger.info("Detecting EEOC stereotype using hybrid mode...")
 
-        # Stage 1: Fast ModernBERT classification in a thread executor
-        # (the HF pipeline call is blocking).
-        loop = asyncio.get_running_loop()
-        score, prediction = await loop.run_in_executor(
-            None, self._classify, dome_input
-        )
+        # Stage 1: fast classification (remote or local)
+        if self._use_vijil_inference:
+            try:
+                async with httpx.AsyncClient(
+                    timeout=self._vijil_client.timeout_seconds
+                ) as client:
+                    score, prediction = await self._classify_vijil(client, dome_input)
+            except Exception as e:
+                logger.error(f"Vijil inference failed in hybrid fast stage: {e}")
+                return False, {
+                    "type": type(self),
+                    "detector": STEREOTYPE_EEOC_HYBRID,
+                    "stage": "vijil-inference-error",
+                    "score": 0.0,
+                    "label": "error",
+                    "error": str(e),
+                    "response_string": dome_input.query_string,
+                }
+        else:
+            loop = asyncio.get_running_loop()
+            score, prediction = await loop.run_in_executor(
+                None, self._classify, dome_input
+            )
+
         confidence = max(score, 1.0 - score)
         logger.debug(
             "stereotype-eeoc-hybrid fast-stage prediction=%s score=%.3f",
@@ -741,12 +911,10 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
             score,
         )
 
-        # Confident enough → return the fast result immediately.
         if confidence >= self.confidence_threshold:
             flagged = score >= self.score_threshold
             return flagged, self._fast_payload(dome_input, score, prediction, stage="fast")
 
-        # Low confidence → escalate to Safeguard if we have a key.
         if not self.api_key:
             flagged = score >= self.score_threshold
             return flagged, self._fast_payload(
@@ -765,19 +933,19 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
     ) -> BatchDetectionResult:
         """Batched hybrid detection.
 
-        Runs the fast ModernBERT stage on the whole batch in one pipeline
-        call (big speedup over the naive per-item loop), then escalates
-        any low-confidence items to Safeguard concurrently via
-        ``asyncio.gather``. Items with enough confidence never touch the
-        API, preserving the hybrid cost model.
+        Runs the fast stage on the whole batch (remote or local), then
+        escalates any low-confidence items to Safeguard concurrently.
         """
         dome_inputs = [DomePayload.coerce(x) for x in inputs]
 
-        # Stage 1: batched fast classification in a thread executor.
-        loop = asyncio.get_running_loop()
-        scored = await loop.run_in_executor(
-            None, self._classify_batch, dome_inputs
-        )
+        # Stage 1: batched fast classification (remote or local).
+        if self._use_vijil_inference:
+            scored = await self._classify_batch_vijil(dome_inputs)
+        else:
+            loop = asyncio.get_running_loop()
+            scored = await loop.run_in_executor(
+                None, self._classify_batch, dome_inputs
+            )
 
         # Partition into "confident enough" vs "escalate".
         results: List[Optional[DetectionResult]] = [None] * len(dome_inputs)
@@ -824,5 +992,4 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
                 for i, r in zip(escalate_indices, escalated):
                     results[i] = r
 
-        # All slots are filled at this point — cast away the Optional.
         return [r for r in results if r is not None]

--- a/vijil_dome/detectors/methods/stereotype_eeoc.py
+++ b/vijil_dome/detectors/methods/stereotype_eeoc.py
@@ -700,6 +700,7 @@ class StereotypeEEOCHybrid(StereotypeEEOCBase):
 
         if self._use_vijil_inference:
             from vijil_dome.detectors.utils.vijil_inference import VijilInferenceClient
+            assert vijil_inference_url is not None
             self.score_threshold = kwargs.get("score_threshold", 0.5)
             self._vijil_client = VijilInferenceClient(
                 base_url=vijil_inference_url,

--- a/vijil_dome/detectors/methods/toxicity_mbert.py
+++ b/vijil_dome/detectors/methods/toxicity_mbert.py
@@ -548,6 +548,7 @@ class ModerationMbertHybrid(MBertToxicContentModel):
 
         if self._use_vijil_inference:
             from vijil_dome.detectors.utils.vijil_inference import VijilInferenceClient
+            assert vijil_inference_url is not None
             self.score_threshold = kwargs.get("score_threshold", 0.5)
             self._vijil_client = VijilInferenceClient(
                 base_url=vijil_inference_url,

--- a/vijil_dome/detectors/methods/toxicity_mbert.py
+++ b/vijil_dome/detectors/methods/toxicity_mbert.py
@@ -28,13 +28,19 @@ import os
 from typing import Dict, List, Optional, Tuple, Union
 
 import httpx
-import torch
-from transformers import pipeline
+
+try:
+    import torch
+    from transformers import pipeline
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
 
 from vijil_dome.detectors import (
     MODERATION_MBERT,
     MODERATION_MBERT_SAFEGUARD,
     MODERATION_MBERT_HYBRID,
+    MODERATION_MBERT_REMOTE,
     register_method,
     DetectionCategory,
     DetectionMethod,
@@ -72,6 +78,9 @@ DEFAULT_SAFEGUARD_API_KEY_NAME = "GROQ_API_KEY"
 DEFAULT_SAFEGUARD_BASE_URL = "https://api.groq.com/openai/v1"
 DEFAULT_SAFEGUARD_MODEL = "openai/gpt-oss-safeguard-20b"
 
+# Default model name on Vijil's inference endpoint (matches HuggingFace).
+DEFAULT_VIJIL_INFERENCE_TOXICITY_MODEL = "vijil/vijil_dome_toxic_content_detection"
+
 
 # ----------------------------------------------------------------------
 # Fast mode (original detector, unchanged interface)
@@ -107,6 +116,11 @@ class MBertToxicContentModel(HFBaseModel):
             Step size in tokens between sliding windows for inputs that
             exceed *max_length*. Default 4096 (half of *max_length*).
         """
+        if not _HAS_TORCH:
+            raise ImportError(
+                f"{MODERATION_MBERT} requires 'torch' and 'transformers'. "
+                "Install with: pip install vijil-dome[local]"
+            )
         try:
             super().__init__(
                 model_name="vijil/vijil_dome_toxic_content_detection",
@@ -421,6 +435,83 @@ class ModerationMbertSafeguard(DetectionMethod):
 
 
 # ----------------------------------------------------------------------
+# Remote mode (Vijil inference endpoint, no local model)
+# ----------------------------------------------------------------------
+
+
+@register_method(DetectionCategory.Moderation, MODERATION_MBERT_REMOTE)
+class MBertToxicContentRemote(DetectionMethod):
+    """Toxicity detection via Vijil's remote inference service.
+
+    Calls Vijil's hosted ModernBERT endpoint — no local model, no torch.
+    Suitable for lightweight deployments where the inference server is
+    co-located or latency is acceptable.
+
+    This detector only works with Vijil's inference endpoint — do not
+    point it at arbitrary OpenAI-compatible services.
+    """
+
+    def __init__(
+        self,
+        vijil_inference_url: str,
+        vijil_inference_model: Optional[str] = None,
+        vijil_inference_api_key: Optional[str] = None,
+        score_threshold: float = 0.5,
+        timeout_seconds: float = 10.0,
+    ):
+        from vijil_dome.detectors.utils.vijil_inference import VijilInferenceClient
+
+        self.score_threshold = score_threshold
+        self.response_string = f"Method:{MODERATION_MBERT_REMOTE}"
+        self.run_in_executor = False
+        self._vijil_client = VijilInferenceClient(
+            base_url=vijil_inference_url,
+            model=vijil_inference_model or DEFAULT_VIJIL_INFERENCE_TOXICITY_MODEL,
+            api_key=vijil_inference_api_key,
+            timeout_seconds=timeout_seconds,
+        )
+        logger.info(
+            "Initialized moderation mbert detector (remote mode, "
+            f"model={self._vijil_client.model}, url={self._vijil_client.base_url})"
+        )
+
+    async def detect(self, dome_input: DomePayload) -> DetectionResult:
+        dome_input = DomePayload.coerce(dome_input)
+        query_string = dome_input.query_string
+        logger.info("Detecting toxicity using Vijil remote inference...")
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._vijil_client.timeout_seconds
+            ) as client:
+                score = await self._vijil_client.classify(client, query_string)
+            flagged = score >= self.score_threshold
+            return flagged, {
+                "type": type(self),
+                "detector": MODERATION_MBERT_REMOTE,
+                "score": score,
+                "label": "toxic" if flagged else "safe",
+                "response_string": self.response_string if flagged else query_string,
+            }
+        except Exception as e:
+            logger.error(f"Vijil remote inference failed: {e}")
+            return False, {
+                "type": type(self),
+                "detector": MODERATION_MBERT_REMOTE,
+                "score": 0.0,
+                "label": "error",
+                "error": str(e),
+                "response_string": query_string,
+            }
+
+    async def detect_batch(
+        self, inputs: List[Union[str, DomePayload]]
+    ) -> BatchDetectionResult:
+        return await self._gather_with_concurrency(
+            [self.detect(DomePayload.coerce(item)) for item in inputs]
+        )
+
+
+# ----------------------------------------------------------------------
 # Hybrid mode (fast + Safeguard escalation)
 # ----------------------------------------------------------------------
 
@@ -428,13 +519,19 @@ class ModerationMbertSafeguard(DetectionMethod):
 @register_method(DetectionCategory.Moderation, MODERATION_MBERT_HYBRID)
 class ModerationMbertHybrid(MBertToxicContentModel):
     """
-    Hybrid toxicity / moderation detection: ModernBERT first, Safeguard on
-    low-confidence. ~5ms average, near-100% accuracy, API cost only on
-    uncertain examples.
+    Hybrid toxicity / moderation detection: fast stage first (local
+    ModernBERT or Vijil remote inference), Safeguard on low-confidence.
+
+    When ``vijil_inference_url`` is provided the fast stage calls Vijil's
+    hosted inference endpoint instead of loading ModernBERT locally,
+    eliminating the torch/transformers dependency for the fast stage.
     """
 
     def __init__(
         self,
+        vijil_inference_url: Optional[str] = None,
+        vijil_inference_model: Optional[str] = None,
+        vijil_inference_api_key: Optional[str] = None,
         confidence_threshold: float = 0.85,
         api_key: Optional[str] = None,
         api_key_name: str = DEFAULT_SAFEGUARD_API_KEY_NAME,
@@ -447,7 +544,19 @@ class ModerationMbertHybrid(MBertToxicContentModel):
         max_input_chars: Optional[int] = DEFAULT_SAFEGUARD_MAX_INPUT_CHARS,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        self._use_vijil_inference = vijil_inference_url is not None
+
+        if self._use_vijil_inference:
+            from vijil_dome.detectors.utils.vijil_inference import VijilInferenceClient
+            self.score_threshold = kwargs.get("score_threshold", 0.5)
+            self._vijil_client = VijilInferenceClient(
+                base_url=vijil_inference_url,
+                model=vijil_inference_model or DEFAULT_VIJIL_INFERENCE_TOXICITY_MODEL,
+                api_key=vijil_inference_api_key,
+            )
+        else:
+            super().__init__(**kwargs)
+
         self.confidence_threshold = confidence_threshold
         self.api_key_name = api_key_name
         self.api_key = api_key or os.environ.get(api_key_name, "")
@@ -466,10 +575,16 @@ class ModerationMbertHybrid(MBertToxicContentModel):
             logger.warning(
                 f"{api_key_name} not set \u2014 {MODERATION_MBERT_HYBRID} will fall back to fast-only"
             )
+        fast_mode = (
+            f"vijil-inference ({self._vijil_client.base_url})"
+            if self._use_vijil_inference
+            else "local"
+        )
         logger.info(
             "Initialized moderation mbert detector "
-            f"(hybrid mode, confidence_threshold={confidence_threshold}, "
-            f"model={model}, base_url={self.base_url})"
+            f"(hybrid mode, fast={fast_mode}, "
+            f"confidence_threshold={confidence_threshold}, "
+            f"safeguard_model={model}, safeguard_url={self.base_url})"
         )
 
     # ------------------------------------------------------------------
@@ -579,6 +694,39 @@ class ModerationMbertHybrid(MBertToxicContentModel):
             return fast_score >= self.score_threshold, payload
 
     # ------------------------------------------------------------------
+    # Vijil remote inference helpers (hybrid fast stage)
+    # ------------------------------------------------------------------
+
+    async def _classify_vijil(
+        self, client: httpx.AsyncClient, dome_input: DomePayload
+    ) -> Tuple[float, dict]:
+        """Classify a single input via Vijil's remote inference endpoint."""
+        score = await self._vijil_client.classify(client, dome_input.query_string)
+        return score, {}
+
+    async def _classify_batch_vijil(
+        self, dome_inputs: List[DomePayload]
+    ) -> List[Tuple[float, dict]]:
+        """Classify a batch via Vijil's remote inference endpoint."""
+        async with httpx.AsyncClient(
+            timeout=self._vijil_client.timeout_seconds
+        ) as client:
+            semaphore = asyncio.Semaphore(self.max_batch_concurrency)
+
+            async def _one(di: DomePayload) -> Tuple[float, dict]:
+                async with semaphore:
+                    try:
+                        score = await self._vijil_client.classify(
+                            client, di.query_string
+                        )
+                        return score, {}
+                    except Exception as e:
+                        logger.error(f"Vijil inference batch item failed: {e}")
+                        return 0.0, {"error": str(e)}
+
+            return list(await asyncio.gather(*(_one(di) for di in dome_inputs)))
+
+    # ------------------------------------------------------------------
     # Public detection interface
     # ------------------------------------------------------------------
 
@@ -586,11 +734,30 @@ class ModerationMbertHybrid(MBertToxicContentModel):
         dome_input = DomePayload.coerce(dome_input)
         logger.info("Detecting toxicity using hybrid mode...")
 
-        # Stage 1: Fast ModernBERT classification in a thread executor
-        loop = asyncio.get_running_loop()
-        score, prediction = await loop.run_in_executor(
-            None, self._classify, dome_input
-        )
+        # Stage 1: fast classification (remote or local)
+        if self._use_vijil_inference:
+            try:
+                async with httpx.AsyncClient(
+                    timeout=self._vijil_client.timeout_seconds
+                ) as client:
+                    score, prediction = await self._classify_vijil(client, dome_input)
+            except Exception as e:
+                logger.error(f"Vijil inference failed in hybrid fast stage: {e}")
+                return False, {
+                    "type": type(self),
+                    "detector": MODERATION_MBERT_HYBRID,
+                    "stage": "vijil-inference-error",
+                    "score": 0.0,
+                    "label": "error",
+                    "error": str(e),
+                    "response_string": dome_input.query_string,
+                }
+        else:
+            loop = asyncio.get_running_loop()
+            score, prediction = await loop.run_in_executor(
+                None, self._classify, dome_input
+            )
+
         confidence = max(score, 1.0 - score)
         logger.debug(
             "moderation-mbert-hybrid fast-stage prediction=%s score=%.3f",
@@ -624,17 +791,19 @@ class ModerationMbertHybrid(MBertToxicContentModel):
     ) -> BatchDetectionResult:
         """Batched hybrid detection.
 
-        Runs the fast ModernBERT stage on the whole batch in one pipeline
-        call, then escalates any low-confidence items to Safeguard
-        concurrently via ``asyncio.gather``.
+        Runs the fast stage on the whole batch (remote or local), then
+        escalates any low-confidence items to Safeguard concurrently.
         """
         dome_inputs = [DomePayload.coerce(x) for x in inputs]
 
-        # Stage 1: batched fast classification in a thread executor.
-        loop = asyncio.get_running_loop()
-        scored = await loop.run_in_executor(
-            None, self._classify_batch, dome_inputs
-        )
+        # Stage 1: batched fast classification (remote or local).
+        if self._use_vijil_inference:
+            scored = await self._classify_batch_vijil(dome_inputs)
+        else:
+            loop = asyncio.get_running_loop()
+            scored = await loop.run_in_executor(
+                None, self._classify_batch, dome_inputs
+            )
 
         # Partition into "confident enough" vs "escalate".
         results: List[Optional[DetectionResult]] = [None] * len(dome_inputs)

--- a/vijil_dome/detectors/utils/hf_model.py
+++ b/vijil_dome/detectors/utils/hf_model.py
@@ -17,7 +17,13 @@
 import logging
 from abc import ABC, abstractmethod
 from typing import Optional
-from transformers import AutoTokenizer, AutoModelForSequenceClassification
+
+try:
+    from transformers import AutoTokenizer, AutoModelForSequenceClassification
+    _HAS_TRANSFORMERS = True
+except ImportError:
+    _HAS_TRANSFORMERS = False
+
 from vijil_dome.detectors import DetectionMethod, DetectionResult
 from vijil_dome.types import DomePayload
 
@@ -36,6 +42,11 @@ class HFBaseModel(DetectionMethod, ABC):
         local_files_only: bool = False,
         trust_remote_code: bool = False,
     ):
+        if not _HAS_TRANSFORMERS:
+            raise ImportError(
+                f"{self.__class__.__name__} requires 'torch' and 'transformers'. "
+                "Install with: pip install vijil-dome[local]"
+            )
         logger.info(f"Initializing Hugging Face model: {model_name}...")
         self.model = AutoModelForSequenceClassification.from_pretrained(
             model_name,

--- a/vijil_dome/detectors/utils/sliding_window.py
+++ b/vijil_dome/detectors/utils/sliding_window.py
@@ -25,9 +25,10 @@ HuggingFace pipeline.
 from __future__ import annotations
 
 import logging
-from typing import List
+from typing import TYPE_CHECKING, List
 
-from transformers import PreTrainedTokenizerBase
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
 
 logger = logging.getLogger("vijil.dome")
 

--- a/vijil_dome/detectors/utils/vijil_inference.py
+++ b/vijil_dome/detectors/utils/vijil_inference.py
@@ -1,0 +1,109 @@
+# Copyright 2025 Vijil, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# vijil and vijil-dome are trademarks owned by Vijil Inc.
+
+"""
+Client for Vijil's hosted ModernBERT inference endpoints.
+
+This module provides a lightweight HTTP client for Vijil's remote model
+inference service.  The endpoint follows an OpenAI-compatible
+``/v1/chat/completions`` shape but returns a **single float score** as
+the assistant message content — it is NOT a general-purpose OpenAI proxy
+and must only be pointed at a Vijil inference deployment.
+
+Usage::
+
+    client = VijilInferenceClient(
+        base_url="https://inference.example.vijil.ai",
+        model="vijil/vijil_dome_prompt_injection_detection",
+    )
+    async with httpx.AsyncClient(timeout=10.0) as http:
+        score = await client.classify(http, "some input text")
+"""
+
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger("vijil.dome")
+
+DEFAULT_VIJIL_INFERENCE_API_KEY_NAME = "VIJIL_INFERENCE_API_KEY"
+
+
+class VijilInferenceClient:
+    """HTTP client for Vijil's hosted model inference service.
+
+    This client is tightly coupled to Vijil's inference endpoint — it
+    expects the response ``content`` to be a single float score.  Do not
+    point it at arbitrary OpenAI-compatible endpoints; use only with
+    Vijil-operated inference deployments.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        api_key: Optional[str] = None,
+        api_key_name: str = DEFAULT_VIJIL_INFERENCE_API_KEY_NAME,
+        timeout_seconds: float = 10.0,
+        max_tokens: int = 32,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.completions_url = f"{self.base_url}/v1/chat/completions"
+        self.model = model
+        self.api_key = api_key or os.environ.get(api_key_name, "")
+        self.timeout_seconds = timeout_seconds
+        self.max_tokens = max_tokens
+
+    def _build_headers(self) -> dict:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _build_payload(self, text: str) -> dict:
+        return {
+            "model": self.model,
+            "messages": [{"role": "user", "content": text}],
+            "max_tokens": self.max_tokens,
+        }
+
+    async def classify(self, client: httpx.AsyncClient, text: str) -> float:
+        """Send *text* to the Vijil inference endpoint and return the score.
+
+        Raises ``ValueError`` if the response content cannot be parsed
+        as a float, or ``httpx.HTTPStatusError`` on non-2xx responses.
+        """
+        resp = await client.post(
+            self.completions_url,
+            headers=self._build_headers(),
+            json=self._build_payload(text),
+        )
+        resp.raise_for_status()
+        content = (
+            resp.json()["choices"][0]["message"].get("content", "").strip()
+        )
+        try:
+            return float(content)
+        except (ValueError, TypeError):
+            logger.error(
+                "Vijil inference returned non-numeric content for model %s: %r "
+                "(expected a float score). Defaulting to 0.0.",
+                self.model,
+                content,
+            )
+            return 0.0


### PR DESCRIPTION
Allows using a Vijil inference stack for all distilled Modernbert models. Makes torch an optional dependency to reduce image/dependency sizes. 