### PR TITLE
feat(agentcore): S3 config polling, OTLP exporters, minimal env

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -61,6 +61,7 @@ vijil_dome/
 │
 ├── integrations/              # Framework integrations (content guards only)
 │   ├── adk/                   # Google ADK DomeCallback
+│   ├── agentcore/             # S3 config poller + OTel shutdown (managed runtimes)
 │   ├── langchain/             # LangChain DomeRunnable
 │   ├── mcp/                   # MCP tool wrapping
 │   ├── strands/               # Strands DomeHookProvider
@@ -193,6 +194,11 @@ poetry run ruff check vijil_dome/ demo/
 | `VIJIL_MODEL_DIR` | `/models` | Local model directory (S3-synced in production) |
 | `VIJIL_CONSOLE_URL` | — | Console URL for constraints and manifest signing |
 | `VIJIL_API_KEY` | — | Console API key |
+| `DOME_CONFIG_S3_BUCKET` | — | With `TEAM_ID` and `AGENT_ID`, enables settings-based S3 config polling in `start_agentcore_background_services()` |
+| `TEAM_ID` | — | `team.id` / `service.namespace` on the AgentCore OTel resource; with `AGENT_ID`, builds `teams/{team}/agents/{agent}/dome/config.json` for settings-based S3 polling; optional `team_id=` on setup overrides |
+| `AGENT_ID` | — | `agent.id` on the OTel resource; with `TEAM_ID` and `DOME_CONFIG_S3_BUCKET`, enables settings-based S3 polling; optional `agent_id=` on setup overrides |
+| `DOME_OTEL_EXPORTER_OTLP_ENDPOINT` | — | Dome OTLP/HTTP base URL for AgentCore exporters (avoids host `OTEL_EXPORTER_OTLP_ENDPOINT`); per-signal `OTEL_EXPORTER_OTLP_*_ENDPOINT` still apply |
+| `DEPLOYMENT_ENVIRONMENT` | `production` | `deployment.environment` on the AgentCore OTel resource when not set |
 
 ## Testing Conventions
 
@@ -227,6 +233,7 @@ poetry run ruff check vijil_dome/ demo/
 - **LangChain**: `DomeRunnable` in chains
 - **MCP**: `DomeMCPWrapper` for tool wrapping
 - **Strands**: `DomeHookProvider` for before/after model hooks
+- **AgentCore / long-lived agents**: `vijil_dome.integrations.agentcore` — S3 config polling when `Dome.create_from_s3()` metadata exists or `DOME_CONFIG_S3_BUCKET` + `TEAM_ID` / `AGENT_ID` are set; OTLP via `DOME_OTEL_EXPORTER_OTLP_ENDPOINT` and `setup_agentcore_otel_for_dome` / `setup_agentcore_otel_exporters_from_env`; coordinated shutdown via `AgentCoreBackgroundServices` / `AgentCoreOtelExporterHandle`. See `vijil_dome/integrations/agentcore/README.md`.
 
 ## Relationship to Other Repos
 

--- a/vijil_dome/Dome.py
+++ b/vijil_dome/Dome.py
@@ -306,6 +306,64 @@ class Dome:
             **(self._s3_aws_kwargs or {}),
         )
 
+    @staticmethod
+    def _equivalent_s3_configs(
+        local: Optional[Dict], remote: Dict
+    ) -> bool:
+        """Return True if *remote* should be treated as unchanged vs *local*.
+
+        Mirrors :func:`vijil_dome.utils.config_loader.config_has_changed` equality
+        semantics (``id`` fast path when both present, else deep dict compare).
+        """
+        if local is None:
+            return False
+        remote_id = remote.get("id")
+        local_id = local.get("id")
+        if remote_id is not None and local_id is not None:
+            return bool(remote_id == local_id)
+        return remote == local
+
+    def reload_from_s3_if_changed(self) -> bool:
+        """Reload guardrails from S3 when the remote config differs from the local snapshot.
+
+        Only available for instances created via :meth:`create_from_s3`. Performs a
+        fresh S3 read (``cache_ttl_seconds=0``), rebuilds guardrails when the config
+        changed, and updates the stored snapshot on the instance.
+
+        Returns:
+            ``True`` if guardrails were rebuilt from a new config, ``False`` if the
+            remote config was equivalent to the current snapshot.
+
+        Raises:
+            ValueError: If the instance was not created from S3.
+        """
+        if self._s3_bucket is None or self._s3_key is None:
+            raise ValueError(
+                "reload_from_s3_if_changed() is only available for Dome instances "
+                "created via Dome.create_from_s3()."
+            )
+        remote = load_dome_config_from_s3(
+            bucket=self._s3_bucket,
+            key=self._s3_key,
+            cache_dir=self._s3_cache_dir,
+            cache_ttl_seconds=0,
+            **(self._s3_aws_kwargs or {}),
+        )
+        if self._equivalent_s3_configs(self._s3_config_dict, remote):
+            return False
+        self._init_from_dome_config(create_dome_config(remote))
+        self._s3_config_dict = remote
+        return True
+
+    def apply_config_dict(self, config_dict: Dict) -> None:
+        """Replace guardrails from a Dome configuration dictionary.
+
+        Used after loading config from S3 (or elsewhere) without requiring
+        :meth:`create_from_s3`. Does not update S3 origin metadata used by
+        :meth:`reload_from_s3_if_changed`.
+        """
+        self._init_from_dome_config(create_dome_config(config_dict))
+
     def _init_from_dome_config(self, dome_config: DomeConfig):
         self.input_guardrail = dome_config.input_guardrail
         self.output_guardrail = dome_config.output_guardrail

--- a/vijil_dome/instrumentation/examples/otel_identity_smoke_test.py
+++ b/vijil_dome/instrumentation/examples/otel_identity_smoke_test.py
@@ -37,6 +37,27 @@ def _auth_header(token: str) -> dict:
     return {"Authorization": f"{method} {token}"}
 
 
+def _append_otlp_signal_path(base_endpoint: str, signal_path: str) -> str:
+    base = base_endpoint.strip()
+    if base.endswith("/"):
+        return f"{base}{signal_path}"
+    return f"{base}/{signal_path}"
+
+
+def _resolved_signal_url(base: str, per_signal_env: str, rel_path: str) -> str:
+    per = os.getenv(per_signal_env, "").strip()
+    if per:
+        return per
+    return _append_otlp_signal_path(base, rel_path)
+
+
+def _collector_auth_headers() -> dict:
+    token = os.getenv("OTEL_COLLECTOR_TOKEN", "").strip()
+    if not token:
+        return {}
+    return _auth_header(token)
+
+
 def _build_resource(agent_id: str | None, team_id: str | None, user_id: str | None) -> Resource:
     attributes = {
         "service.name": "vijil-dome-telemetry-smoke",
@@ -53,32 +74,35 @@ def _build_resource(agent_id: str | None, team_id: str | None, user_id: str | No
 
 
 def _create_log_handler(resource: Resource) -> tuple[LoggerProvider, LoggingHandler]:
-    endpoint = _required_env("DOME_LOGS_COLLECTOR_ENDPOINT")
-    token = _required_env("DOME_LOGS_COLLECTOR_TOKEN")
+    base = _required_env("DOME_OTEL_EXPORTER_OTLP_ENDPOINT")
+    endpoint = _resolved_signal_url(base, "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "v1/logs")
+    headers = _collector_auth_headers()
 
     provider = LoggerProvider(resource=resource)
     set_logger_provider(provider)
-    exporter = OTLPLogExporter(endpoint=endpoint, headers=_auth_header(token))
+    exporter = OTLPLogExporter(endpoint=endpoint, headers=headers)
     provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
     return provider, LoggingHandler(level=logging.INFO, logger_provider=provider)
 
 
 def _create_tracer(resource: Resource):
-    endpoint = _required_env("DOME_TRACES_COLLECTOR_ENDPOINT")
-    token = _required_env("DOME_TRACES_COLLECTOR_TOKEN")
+    base = _required_env("DOME_OTEL_EXPORTER_OTLP_ENDPOINT")
+    endpoint = _resolved_signal_url(base, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "v1/traces")
+    headers = _collector_auth_headers()
 
     provider = TracerProvider(resource=resource)
     trace.set_tracer_provider(provider)
-    exporter = OTLPSpanExporter(endpoint=endpoint, headers=_auth_header(token))
+    exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
     provider.add_span_processor(BatchSpanProcessor(exporter))
     return provider, provider.get_tracer("vijil-dome-telemetry-smoke")
 
 
 def _create_meter(resource: Resource):
-    endpoint = _required_env("DOME_METRICS_COLLECTOR_ENDPOINT")
-    token = _required_env("DOME_METRICS_COLLECTOR_TOKEN")
+    base = _required_env("DOME_OTEL_EXPORTER_OTLP_ENDPOINT")
+    endpoint = _resolved_signal_url(base, "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "v1/metrics")
+    headers = _collector_auth_headers()
 
-    exporter = OTLPMetricExporter(endpoint=endpoint, headers=_auth_header(token))
+    exporter = OTLPMetricExporter(endpoint=endpoint, headers=headers)
     reader = PeriodicExportingMetricReader(exporter)
     provider = MeterProvider(metric_readers=[reader], resource=resource)
     metrics.set_meter_provider(provider)

--- a/vijil_dome/integrations/agentcore/README.md
+++ b/vijil_dome/integrations/agentcore/README.md
@@ -1,0 +1,181 @@
+# AgentCore integration (S3 config polling + telemetry shutdown)
+
+Optional helpers for long-lived agents (for example on AWS AgentCore) that load Dome
+configuration from S3 and export OpenTelemetry. **S3 polling** starts when
+`start_agentcore_background_services` sees either `Dome.create_from_s3()` metadata on the
+instance, or `DOME_CONFIG_S3_BUCKET` plus `TEAM_ID` and `AGENT_ID` on settings. **OTLP
+exporters** install when `DOME_OTEL_EXPORTER_OTLP_ENDPOINT` is set (or per-signal
+`OTEL_EXPORTER_OTLP_*_ENDPOINT` only), unless you pass `enabled=False` to the setup helpers.
+
+## Install
+
+```bash
+pip install 'vijil-dome[s3,opentelemetry]'
+```
+
+With Poetry, enable the ``s3`` and ``opentelemetry`` optional dependency groups.
+
+`boto3` is required for S3 reload; the OpenTelemetry SDK is required for OTLP
+exporters and graceful shutdown.
+
+## One-call telemetry + Dome hooks (recommended)
+
+``setup_agentcore_otel_for_dome(dome, settings=…)`` configures OTLP/HTTP exporters (same
+as ``setup_agentcore_otel_exporters_from_env``) and attaches Dome guardrail
+instrumentation—traces, metrics, and Darwin-style ``dome-detection`` spans—using the
+global tracer and meter. Pass the returned handle to ``start_agentcore_background_services``;
+when the S3 config poller runs, it invokes ``reinstrument_dome`` on that handle
+**before** your ``on_s3_reload`` callback so reloaded guardrails stay wired.
+
+```python
+from vijil_dome.integrations.agentcore import (
+    load_agentcore_runtime_settings_from_env,
+    setup_agentcore_otel_for_dome,
+    start_agentcore_background_services,
+)
+
+settings = load_agentcore_runtime_settings_from_env()
+otel = setup_agentcore_otel_for_dome(dome, settings=settings)
+bg = start_agentcore_background_services(
+    dome, settings=settings, otel_exporter_handle=otel
+)
+```
+
+Use ``setup_agentcore_otel_exporters_from_env`` only when you need OTLP export without
+calling ``instrument_dome`` (custom integration).
+
+### Coexisting with host ``setup_telemetry``
+
+If your runtime already calls ``setup_telemetry(service_name="...")`` (or otherwise sets
+global SDK tracer/meter providers), initialize Dome **after** that. vijil-dome detects
+existing providers, skips ``set_tracer_provider`` / ``set_meter_provider`` (so you avoid
+OpenTelemetry's "Overriding ... is not allowed" warnings), still runs
+``instrument_dome``, and returns a handle whose ``manages_global_providers`` is false so
+``handle.shutdown()`` does not shut down the host's providers (your framework should still
+flush telemetry on process exit).
+
+Dome OTLP uses ``DOME_OTEL_EXPORTER_OTLP_ENDPOINT`` (not ``OTEL_EXPORTER_OTLP_ENDPOINT``) so
+it does not fight the host's default OpenTelemetry env configuration.
+
+## Environment variables (AgentCore)
+
+These populate :class:`~.settings.AgentCoreRuntimeSettings` via
+``load_agentcore_runtime_settings_from_env()``. Pass that object to
+``setup_agentcore_otel_for_dome(dome, settings=…)`` (or the exporter-only helper) and
+``start_agentcore_background_services(dome, settings=…)`` so S3 polling and OTLP export
+see the same values.
+
+| Variable | Purpose |
+|----------|---------|
+| `TEAM_ID` | `team.id` / `service.namespace` on the OTel resource; with `AGENT_ID`, builds S3 key `teams/{team}/agents/{agent}/dome/config.json` for settings-based polling. Override with `team_id=` on setup. |
+| `AGENT_ID` | `agent.id` on the OTel resource and S3 key segment (required for settings-based polling with `DOME_CONFIG_S3_BUCKET`). Override with `agent_id=` on setup. |
+| `DOME_CONFIG_S3_BUCKET` | Bucket for that config key when **not** using `Dome.create_from_s3()`. With `TEAM_ID` and `AGENT_ID`, enables the S3 config poller in `start_agentcore_background_services`. |
+| `DOME_OTEL_EXPORTER_OTLP_ENDPOINT` | Dome OTLP/HTTP **base** URL; paths `v1/traces`, `v1/metrics`, and `v1/logs` are appended per signal unless you set matching `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` / `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`. |
+| `DEPLOYMENT_ENVIRONMENT` | `deployment.environment` on the OTel resource (default `production`). |
+
+## OpenTelemetry (optional extras)
+
+Headers, timeouts, compression, and **per-signal** OTLP URLs follow the standard
+OpenTelemetry names (for example `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TIMEOUT`,
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`). The **base** URL for Dome-managed exporters is only
+`DOME_OTEL_EXPORTER_OTLP_ENDPOINT` on :class:`~.settings.AgentCoreRuntimeSettings`; the
+process-wide `OTEL_EXPORTER_OTLP_ENDPOINT` is not read by AgentCore setup.
+
+**Resource** attributes come from `create_agentcore_otel_resource` (fixed `service.name=vijil.dome`,
+`team.id`, optional `agent.id`, no `service.instance.id` / `service.ip`) so DELTA counters
+from many short-lived sessions stay on one series for the same team/agent.
+
+**Counter**, **UpDownCounter**, **ObservableCounter**, and **ObservableUpDownCounter** use
+**delta** temporality on the OTLP metric exporter; **Histogram** and **ObservableGauge**
+keep default temporality (see `setup_agentcore_otel_exporters_from_env`).
+
+## Typical lifecycle
+
+### A. `Dome.create_from_s3` (existing)
+
+1. Create `Dome` with `Dome.create_from_s3(...)` (bucket/key/cache as today).
+2. Optionally export `TEAM_ID` / `AGENT_ID`, `DOME_OTEL_EXPORTER_OTLP_ENDPOINT`, and/or `DOME_CONFIG_S3_BUCKET` as needed (see table).
+3. **Telemetry (optional)** — when `DOME_OTEL_EXPORTER_OTLP_ENDPOINT` is set (or per-signal OTLP env only), install exporters once at startup:
+
+   ```python
+   from vijil_dome.integrations.agentcore import (
+       load_agentcore_runtime_settings_from_env,
+       setup_agentcore_otel_for_dome,
+       start_agentcore_background_services,
+   )
+
+   settings = load_agentcore_runtime_settings_from_env()
+   otel = setup_agentcore_otel_for_dome(dome, settings=settings)
+   ```
+
+4. **Background poller** — starts automatically for `create_from_s3` domes (S3 metadata on the instance). For settings-driven polling, set `DOME_CONFIG_S3_BUCKET`, `TEAM_ID`, and `AGENT_ID`.
+
+   ```python
+   dome = Dome.create_from_s3(bucket, team_id=team_id, agent_id=agent_id)
+   bg = start_agentcore_background_services(dome, settings=settings, otel_exporter_handle=otel)
+   ```
+
+   Poll interval is fixed at **300 seconds** unless you pass `poll_interval_seconds=` to `start_agentcore_background_services` (for tests or special cases).
+
+### Shutdown (both paths)
+
+On shutdown (SIGTERM, `atexit`, framework `on_stop`, etc.):
+
+```python
+bg.shutdown(join_timeout=15.0)
+```
+
+`shutdown` stops the S3 poller first, then calls `otel.shutdown()` if you passed
+`otel_exporter_handle`, which removes the optional stdlib logging bridge and shuts
+down global tracer, meter, and logger providers. If you initialized OTel elsewhere
+without a handle, call `shutdown_opentelemetry_providers()` yourself after `bg.shutdown()`.
+
+### B. Local `Dome` + settings-driven S3 polling (no `create_from_s3`)
+
+1. Build `Dome` from a dict or file as usual.
+2. Set `DOME_CONFIG_S3_BUCKET`, `TEAM_ID`, and `AGENT_ID` (S3 key is always the standard `teams/{team}/agents/{agent}/dome/config.json` path).
+3. Use the same `settings` object for OTel and `start_agentcore_background_services` as in (A).
+
+On each poll tick, config is loaded with `load_dome_config_from_s3` and applied via
+`Dome.apply_config_dict` (no `create_from_s3` required).
+
+## Programmatic control (no env)
+
+```python
+from vijil_dome.integrations.agentcore import (
+    AgentCoreRuntimeSettings,
+    DomeS3ConfigPoller,
+    setup_agentcore_otel_for_dome,
+    shutdown_opentelemetry_providers,
+)
+
+settings = AgentCoreRuntimeSettings(
+    s3_config_bucket="my-bucket",
+    team_id="t",
+    agent_id="a",
+    otel_exporter_otlp_endpoint="http://localhost:4318",
+)
+poller = DomeS3ConfigPoller(dome, settings, interval_seconds=60.0)
+poller.start()
+otel = setup_agentcore_otel_for_dome(dome, enabled=True, settings=settings)
+# ... later ...
+poller.stop()
+if otel:
+    otel.shutdown()
+else:
+    shutdown_opentelemetry_providers()
+```
+
+## Manual reload without a poller
+
+S3-backed `Dome` from `create_from_s3`:
+
+```python
+if dome.reload_from_s3_if_changed():
+    ...
+```
+
+Or load JSON yourself and call `dome.apply_config_dict(remote_dict)`.
+
+Change detection for the poller matches `Dome.config_has_changed()` semantics (including
+`id`-based fast path when present).

--- a/vijil_dome/integrations/agentcore/__init__.py
+++ b/vijil_dome/integrations/agentcore/__init__.py
@@ -1,0 +1,48 @@
+# Copyright 2025 Vijil, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AgentCore-oriented helpers: env-driven S3 config polling and OTel lifecycle."""
+
+from .background import (
+    AGENTCORE_S3_POLL_INTERVAL_SECONDS,
+    AgentCoreBackgroundServices,
+    DomeS3ConfigPoller,
+    combine_agentcore_s3_reload_callbacks,
+    start_agentcore_background_services,
+)
+from .otel_exporters import (
+    AgentCoreDomeOtelExporterHandle,
+    AgentCoreOtelExporterHandle,
+    create_agentcore_otel_resource,
+    setup_agentcore_otel_exporters_from_env,
+    setup_agentcore_otel_for_dome,
+)
+from .otel_lifecycle import shutdown_opentelemetry_providers
+from .settings import AgentCoreRuntimeSettings, load_agentcore_runtime_settings_from_env
+
+__all__ = [
+    "AGENTCORE_S3_POLL_INTERVAL_SECONDS",
+    "AgentCoreBackgroundServices",
+    "AgentCoreDomeOtelExporterHandle",
+    "AgentCoreOtelExporterHandle",
+    "AgentCoreRuntimeSettings",
+    "combine_agentcore_s3_reload_callbacks",
+    "create_agentcore_otel_resource",
+    "DomeS3ConfigPoller",
+    "load_agentcore_runtime_settings_from_env",
+    "setup_agentcore_otel_exporters_from_env",
+    "setup_agentcore_otel_for_dome",
+    "shutdown_opentelemetry_providers",
+    "start_agentcore_background_services",
+]

--- a/vijil_dome/integrations/agentcore/background.py
+++ b/vijil_dome/integrations/agentcore/background.py
@@ -1,0 +1,271 @@
+# Copyright 2025 Vijil, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Background S3 config polling and coordinated shutdown for long-lived agents."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING, Callable, Dict, Optional
+
+from vijil_dome.Dome import Dome
+from vijil_dome.utils.config_loader import build_s3_config_key, load_dome_config_from_s3
+
+from .settings import AgentCoreRuntimeSettings, load_agentcore_runtime_settings_from_env
+
+if TYPE_CHECKING:
+    from .otel_exporters import AgentCoreOtelExporterHandle
+
+logger = logging.getLogger("vijil.dome")
+
+# Fixed interval when :func:`start_agentcore_background_services` starts the S3 poller.
+AGENTCORE_S3_POLL_INTERVAL_SECONDS = 300.0
+
+
+def _should_start_s3_config_poller(dome: Dome, settings: AgentCoreRuntimeSettings) -> bool:
+    """True if *dome* was built with S3 origin metadata, or *settings* has bucket + team + agent."""
+    if dome._s3_bucket is not None and dome._s3_key is not None:
+        return True
+    return bool(
+        settings.s3_config_bucket
+        and (settings.team_id or "").strip()
+        and (settings.agent_id or "").strip()
+    )
+
+
+def combine_agentcore_s3_reload_callbacks(
+    *,
+    otel_exporter_handle: Optional["AgentCoreOtelExporterHandle"] = None,
+    on_s3_reload: Optional[Callable[[Dome], None]] = None,
+) -> Optional[Callable[[Dome], None]]:
+    """Return a callback that re-instruments OTel on *dome* (when supported), then *on_s3_reload*.
+
+    If *otel_exporter_handle* provides ``reinstrument_dome`` (as with
+    :func:`vijil_dome.integrations.agentcore.otel_exporters.setup_agentcore_otel_for_dome`),
+    it is invoked first so traces, metrics, and Darwin spans attach to guardrails loaded from S3.
+    """
+    if otel_exporter_handle is None:
+        return on_s3_reload
+    rd = getattr(otel_exporter_handle, "reinstrument_dome", None)
+    if rd is None or not callable(rd):
+        return on_s3_reload
+    user_cb = on_s3_reload
+
+    def merged(d: Dome) -> None:
+        rd(d)
+        if user_cb is not None:
+            user_cb(d)
+
+    return merged
+
+
+class DomeS3ConfigPoller:
+    """Background thread that reloads Dome config from S3 on an interval.
+
+    Two modes:
+
+    - **Dome origin** — *dome* was created with :meth:`~vijil_dome.Dome.Dome.create_from_s3`;
+      each tick calls :meth:`~vijil_dome.Dome.Dome.reload_from_s3_if_changed`.
+    - **Settings** — *settings* supplies ``s3_config_bucket`` plus ``team_id`` and ``agent_id``
+      (key from :func:`~vijil_dome.utils.config_loader.build_s3_config_key`); each tick loads
+      JSON and applies via :meth:`~vijil_dome.Dome.Dome.apply_config_dict`.
+
+    The poller does not start automatically; call :meth:`start` after your agent is ready,
+    and :meth:`stop` during graceful shutdown. The first poll runs after the first
+    *interval_seconds* wait (not immediately).
+    """
+
+    def __init__(
+        self,
+        dome: Dome,
+        settings: AgentCoreRuntimeSettings,
+        interval_seconds: float = 300.0,
+        *,
+        on_reload: Optional[Callable[[Dome], None]] = None,
+        thread_name: str = "vijil-dome-s3-config-poller",
+        daemon: bool = False,
+    ) -> None:
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+        self._dome = dome
+        self._settings = settings
+        self._interval = interval_seconds
+        self._on_reload = on_reload
+        self._thread_name = thread_name
+        self._daemon = daemon
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._poll_mode: str = ""
+        self._last_remote: Optional[Dict] = None
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            logger.warning("DomeS3ConfigPoller.start() called while thread is already running")
+            return
+        if self._dome._s3_bucket is not None and self._dome._s3_key is not None:
+            self._poll_mode = "dome_origin"
+            self._last_remote = getattr(self._dome, "_s3_config_dict", None)
+        elif (
+            self._settings.s3_config_bucket
+            and self._settings.team_id
+            and self._settings.agent_id
+        ):
+            self._poll_mode = "settings"
+            self._last_remote = None
+        else:
+            raise ValueError(
+                "DomeS3ConfigPoller requires either Dome.create_from_s3() metadata on dome, or "
+                "AgentCoreRuntimeSettings with s3_config_bucket, team_id, and agent_id."
+            )
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=self._thread_name,
+            daemon=self._daemon,
+        )
+        self._thread.start()
+        logger.info(
+            "Started Dome S3 config poller (mode=%s, interval=%ss, daemon=%s)",
+            self._poll_mode,
+            self._interval,
+            self._daemon,
+        )
+
+    def stop(self, *, join_timeout: float = 15.0) -> None:
+        """Signal the poller to exit and wait for the thread to finish."""
+        self._stop.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=join_timeout)
+            if self._thread.is_alive():
+                logger.warning(
+                    "DomeS3ConfigPoller thread did not exit within join_timeout=%s",
+                    join_timeout,
+                )
+        self._thread = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def _poll_via_settings(self) -> bool:
+        bucket = self._settings.s3_config_bucket
+        assert bucket is not None
+        aid = self._settings.agent_id or ""
+        key = build_s3_config_key(self._settings.team_id, aid)
+        remote = load_dome_config_from_s3(bucket=bucket, key=key, cache_ttl_seconds=0)
+        if Dome._equivalent_s3_configs(self._last_remote, remote):
+            return False
+        self._dome.apply_config_dict(remote)
+        self._last_remote = remote
+        return True
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            if self._stop.wait(self._interval):
+                break
+            try:
+                if self._poll_mode == "dome_origin":
+                    changed = self._dome.reload_from_s3_if_changed()
+                else:
+                    changed = self._poll_via_settings()
+                if changed:
+                    logger.info("Dome guardrails reloaded from S3")
+                    if self._on_reload is not None:
+                        try:
+                            self._on_reload(self._dome)
+                        except Exception:
+                            logger.exception("on_reload callback failed")
+            except Exception:
+                logger.exception("Dome S3 config poll iteration failed")
+
+
+class AgentCoreBackgroundServices:
+    """Coordinates optional S3 polling and optional OTel exporter teardown.
+
+    Construct via :func:`start_agentcore_background_services` so defaults and env
+    wiring stay consistent.
+    """
+
+    def __init__(
+        self,
+        *,
+        poller: Optional[DomeS3ConfigPoller],
+        settings: AgentCoreRuntimeSettings,
+        otel_exporter_handle: Optional["AgentCoreOtelExporterHandle"] = None,
+    ) -> None:
+        self._poller = poller
+        self._settings = settings
+        self._otel_exporter_handle = otel_exporter_handle
+
+    def shutdown(self, *, join_timeout: float = 15.0) -> None:
+        """Stop background threads; if an OTel handle was passed in, shut it down."""
+        if self._poller is not None:
+            self._poller.stop(join_timeout=join_timeout)
+        if self._otel_exporter_handle is not None:
+            self._otel_exporter_handle.shutdown()
+
+
+def start_agentcore_background_services(
+    dome: Dome,
+    *,
+    settings: Optional[AgentCoreRuntimeSettings] = None,
+    on_s3_reload: Optional[Callable[[Dome], None]] = None,
+    otel_exporter_handle: Optional["AgentCoreOtelExporterHandle"] = None,
+    poll_interval_seconds: float = AGENTCORE_S3_POLL_INTERVAL_SECONDS,
+) -> AgentCoreBackgroundServices:
+    """Build (and optionally start) background services from explicit or env settings.
+
+    If *settings* is omitted, values are read from :func:`load_agentcore_runtime_settings_from_env`.
+
+    A :class:`DomeS3ConfigPoller` is created and **started** when *dome* was created with
+    :meth:`~vijil_dome.Dome.Dome.create_from_s3` (S3 metadata on the instance), or when
+    *settings* supplies ``DOME_CONFIG_S3_BUCKET``-backed ``s3_config_bucket`` together with
+    non-empty ``team_id`` and ``agent_id``. Otherwise no poller runs. Poll interval defaults
+    to :data:`AGENTCORE_S3_POLL_INTERVAL_SECONDS` (300s); override *poll_interval_seconds*
+    for tests or special deployments (not read from the environment).
+
+    Always call :meth:`AgentCoreBackgroundServices.shutdown` from your agent's shutdown path
+    (signal handler, ``atexit``, framework hook, etc.).
+
+    Pass *otel_exporter_handle* (for example from :func:`setup_agentcore_otel_for_dome` or
+    :func:`setup_agentcore_otel_exporters_from_env`) so :meth:`~AgentCoreBackgroundServices.shutdown`
+    calls :meth:`AgentCoreOtelExporterHandle.shutdown` and flushes global OTel providers.
+
+    When the poller runs and *otel_exporter_handle* implements ``reinstrument_dome``
+    (the handle from :func:`~vijil_dome.integrations.agentcore.otel_exporters.setup_agentcore_otel_for_dome`),
+    the S3 reload callback automatically invokes it **before** *on_s3_reload* so new
+    guardrails stay instrumented.
+
+    Install extras for full functionality: ``pip install 'vijil-dome[s3,opentelemetry]'``.
+    """
+    resolved = settings or load_agentcore_runtime_settings_from_env()
+    poller: Optional[DomeS3ConfigPoller] = None
+    merged_reload = combine_agentcore_s3_reload_callbacks(
+        otel_exporter_handle=otel_exporter_handle,
+        on_s3_reload=on_s3_reload,
+    )
+    if _should_start_s3_config_poller(dome, resolved):
+        poller = DomeS3ConfigPoller(
+            dome,
+            resolved,
+            interval_seconds=poll_interval_seconds,
+            on_reload=merged_reload,
+        )
+        poller.start()
+    return AgentCoreBackgroundServices(
+        poller=poller,
+        settings=resolved,
+        otel_exporter_handle=otel_exporter_handle,
+    )

--- a/vijil_dome/integrations/agentcore/otel_exporters.py
+++ b/vijil_dome/integrations/agentcore/otel_exporters.py
@@ -1,0 +1,496 @@
+# Copyright 2025 Vijil, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Initialize OTLP/HTTP trace, metric, and log exporters (env + :class:`~.settings.AgentCoreRuntimeSettings`)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from vijil_dome.Dome import Dome
+
+    from .settings import AgentCoreRuntimeSettings
+
+logger = logging.getLogger("vijil.dome")
+
+_INSTRUMENTATION_NAME = "vijil.dome"
+
+
+def _agentcore_instrumentation_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("vijil-dome")
+    except Exception:
+        return "0.0.0"
+
+
+def _apply_dome_otel_instrumentation(
+    dome: "Dome",
+    *,
+    bridge_stdlib_logging: bool,
+    bridge_logger_name: str,
+) -> None:
+    """Wire :func:`~vijil_dome.integrations.instrumentation.otel_instrumentation.instrument_dome` to global providers."""
+    from opentelemetry import metrics, trace
+
+    from vijil_dome.integrations.instrumentation.otel_instrumentation import (
+        instrument_dome,
+        instrument_logger,
+    )
+
+    ver = _agentcore_instrumentation_version()
+    tracer = trace.get_tracer(_INSTRUMENTATION_NAME, ver)
+    meter = metrics.get_meter(_INSTRUMENTATION_NAME, ver)
+    # LoggingHandler is already attached by :func:`setup_agentcore_otel_exporters_from_env`;
+    # avoid registering it twice via ``instrument_dome(..., handler=...)``.
+    instrument_dome(dome, None, tracer, meter)
+    if bridge_stdlib_logging:
+        instrument_logger(logging.getLogger(bridge_logger_name))
+
+
+def _env_nonempty(name: str) -> bool:
+    return bool(os.environ.get(name, "").strip())
+
+
+def _has_any_otlp_endpoint_env() -> bool:
+    """True if env supplies per-signal OTLP/HTTP endpoints (not the host base ``OTEL_EXPORTER_OTLP_ENDPOINT``)."""
+    keys = (
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    )
+    return any(_env_nonempty(k) for k in keys)
+
+
+def _append_otlp_signal_path(base_endpoint: str, signal_path: str) -> str:
+    """Append ``v1/traces``-style path the same way OTLP HTTP exporters do."""
+    base = base_endpoint.strip()
+    if base.endswith("/"):
+        return f"{base}{signal_path}"
+    return f"{base}/{signal_path}"
+
+
+def _has_otlp_endpoint_config(settings: "AgentCoreRuntimeSettings") -> bool:
+    if (settings.otel_exporter_otlp_endpoint or "").strip():
+        return True
+    return _has_any_otlp_endpoint_env()
+
+
+def _resolved_trace_otlp_endpoint(settings: "AgentCoreRuntimeSettings") -> Optional[str]:
+    base = (settings.otel_exporter_otlp_endpoint or "").strip()
+    if base:
+        return _append_otlp_signal_path(base, "v1/traces")
+    return os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "").strip() or None
+
+
+def _resolved_metrics_otlp_endpoint(settings: "AgentCoreRuntimeSettings") -> Optional[str]:
+    base = (settings.otel_exporter_otlp_endpoint or "").strip()
+    if base:
+        return _append_otlp_signal_path(base, "v1/metrics")
+    return os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "").strip() or None
+
+
+def _resolved_logs_otlp_endpoint(settings: "AgentCoreRuntimeSettings") -> Optional[str]:
+    base = (settings.otel_exporter_otlp_endpoint or "").strip()
+    if base:
+        return _append_otlp_signal_path(base, "v1/logs")
+    return os.environ.get("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "").strip() or None
+
+
+def _global_otel_sdk_providers_already_set() -> bool:
+    """True if the process already has SDK tracer or meter providers (not OTel proxies)."""
+    try:
+        from opentelemetry import metrics, trace
+        from opentelemetry.sdk.metrics import MeterProvider as SDKMeterProvider
+        from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+    except ImportError:
+        return False
+
+    return isinstance(trace.get_tracer_provider(), SDKTracerProvider) or isinstance(
+        metrics.get_meter_provider(), SDKMeterProvider
+    )
+
+
+def create_agentcore_otel_resource(
+    team_id: str = "",
+    agent_id: Optional[str] = None,
+):
+    """Build a stable :class:`~opentelemetry.sdk.resources.Resource` for AgentCore OTLP export.
+
+    Uses ``team.id`` and optional ``agent.id`` so DELTA counter series stay aligned across
+    short-lived sessions for the same team/agent. Omits ``service.instance.id`` and
+    ``service.ip`` so labels stay shared and backends can sum deltas into cumulative views.
+
+    ``deployment.environment`` defaults to ``production`` or ``DEPLOYMENT_ENVIRONMENT``.
+    ``service.version`` comes from the installed ``vijil-dome`` package metadata (same
+    helper as tracer/meter instrumentation); falls back to ``0.0.0`` if unavailable.
+
+    Requires the ``opentelemetry`` optional dependency (``Resource`` from the SDK).
+    """
+    from opentelemetry.sdk.resources import Resource
+
+    attributes = {
+        "service.name": "vijil.dome",
+        "service.namespace": team_id,
+        "service.version": _agentcore_instrumentation_version(),
+        "deployment.environment": os.getenv("DEPLOYMENT_ENVIRONMENT", "production"),
+        "team.id": team_id,
+    }
+    if agent_id:
+        attributes["agent.id"] = agent_id
+    return Resource(attributes=attributes)
+
+
+class AgentCoreOtelExporterHandle:
+    """Holds references created by :func:`setup_agentcore_otel_exporters_from_env`.
+
+    Call :meth:`shutdown` during agent teardown (after stopping other background
+    threads) so batch processors and the metrics export interval flush cleanly.
+
+    For exporter setup **plus** Dome guardrail wiring in one step, use
+    :func:`setup_agentcore_otel_for_dome`, which returns a subclass with
+    :meth:`AgentCoreDomeOtelExporterHandle.reinstrument_dome`.
+    """
+
+    def __init__(
+        self,
+        *,
+        bridge_handler: Optional[logging.Handler] = None,
+        bridge_logger_name: Optional[str] = None,
+        manages_global_providers: bool = True,
+    ) -> None:
+        self._bridge_handler = bridge_handler
+        self._bridge_logger_name = bridge_logger_name
+        self._manages_global_providers = manages_global_providers
+
+    @property
+    def manages_global_providers(self) -> bool:
+        """False when exporters were skipped because another component owns global providers."""
+        return self._manages_global_providers
+
+    @property
+    def bridge_handler(self) -> Optional[logging.Handler]:
+        return self._bridge_handler
+
+    @property
+    def bridge_logger_name(self) -> Optional[str]:
+        return self._bridge_logger_name
+
+    def shutdown(self) -> None:
+        """Remove optional stdlib bridge handler, then shut down global OTel providers."""
+        if self._bridge_handler is not None and self._bridge_logger_name:
+            lg = logging.getLogger(self._bridge_logger_name)
+            if self._bridge_handler in lg.handlers:
+                lg.removeHandler(self._bridge_handler)
+            try:
+                self._bridge_handler.close()
+            except Exception:
+                logger.exception("Error closing OTel logging bridge handler")
+            self._bridge_handler = None
+            self._bridge_logger_name = None
+
+        from .otel_lifecycle import shutdown_opentelemetry_providers
+
+        if self._manages_global_providers:
+            shutdown_opentelemetry_providers()
+
+
+class AgentCoreDomeOtelExporterHandle(AgentCoreOtelExporterHandle):
+    """Return type of :func:`setup_agentcore_otel_for_dome` — OTLP handle plus Dome hooks."""
+
+    def __init__(
+        self,
+        *,
+        bridge_handler: Optional[logging.Handler] = None,
+        bridge_logger_name: Optional[str] = None,
+        attach_stdlib_log_formatting: bool = True,
+        use_bridge_logger_name: str = "vijil.dome",
+        manages_global_providers: bool = True,
+    ) -> None:
+        super().__init__(
+            bridge_handler=bridge_handler,
+            bridge_logger_name=bridge_logger_name,
+            manages_global_providers=manages_global_providers,
+        )
+        self._attach_stdlib_log_formatting = attach_stdlib_log_formatting
+        self._use_bridge_logger_name = use_bridge_logger_name
+
+    def reinstrument_dome(self, dome: "Dome") -> None:
+        """Re-attach traces, metrics, and Darwin spans after guardrails were replaced.
+
+        Call after :meth:`~vijil_dome.Dome.Dome.apply_config_dict` or any S3 reload that
+        swaps ``input_guardrail`` / ``output_guardrail``. Used automatically by
+        :func:`start_agentcore_background_services` when this handle is passed as
+        *otel_exporter_handle* and the S3 config poller is running.
+        """
+        _apply_dome_otel_instrumentation(
+            dome,
+            bridge_stdlib_logging=self._attach_stdlib_log_formatting,
+            bridge_logger_name=self._use_bridge_logger_name,
+        )
+
+
+def setup_agentcore_otel_exporters_from_env(
+    *,
+    enabled: Optional[bool] = None,
+    settings: Optional["AgentCoreRuntimeSettings"] = None,
+    team_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    bridge_stdlib_logging: bool = True,
+    bridge_logger_name: str = "vijil.dome",
+) -> Optional[AgentCoreOtelExporterHandle]:
+    """Configure global OTLP-over-HTTP exporters for **traces**, **metrics**, and **logs**.
+
+    This is **opt-in** when *enabled* is ``None``: exporters install only if an OTLP HTTP
+    endpoint is configured (non-empty ``DOME_OTEL_EXPORTER_OTLP_ENDPOINT`` on *settings*,
+    or per-signal ``OTEL_EXPORTER_OTLP_*_ENDPOINT`` in the environment). Pass ``enabled=False``
+    to skip, or ``enabled=True`` to force an attempt (logs a warning and returns ``None``
+    if no endpoint is found).
+
+    The host-wide ``OTEL_EXPORTER_OTLP_ENDPOINT`` is intentionally **not** read here so it
+    does not collide with other OpenTelemetry setup in the same process.
+
+    Other common variables are read **automatically** by the OpenTelemetry Python
+    exporters when constructed with default arguments, including:
+
+    - ``OTEL_EXPORTER_OTLP_HEADERS`` / per-signal ``OTEL_EXPORTER_OTLP_*_HEADERS``
+    - ``OTEL_EXPORTER_OTLP_TIMEOUT`` / per-signal timeouts
+
+    If the process already has an SDK :class:`~opentelemetry.sdk.trace.TracerProvider`
+    or :class:`~opentelemetry.sdk.metrics.MeterProvider` (for example from host
+    ``setup_telemetry``), this function **does not** call ``set_tracer_provider`` /
+    ``set_meter_provider`` again (which would only log warnings and be ignored). It
+    returns a handle with ``manages_global_providers`` false; use
+    :func:`setup_agentcore_otel_for_dome` so Dome still attaches to the existing providers.
+
+    Resource attributes use :func:`create_agentcore_otel_resource` (stable ``service.name``,
+    ``team.id``, optional ``agent.id``) so DELTA counters from many sessions map to one
+    logical series. Resolve ``team_id`` / ``agent_id`` from explicit arguments when
+    provided; otherwise from *settings* (or :func:`~.settings.load_agentcore_runtime_settings_from_env`
+    when *settings* is omitted), which reads ``TEAM_ID`` / ``AGENT_ID``. Set
+    ``DEPLOYMENT_ENVIRONMENT`` for ``deployment.environment`` (default ``production``).
+
+    Metrics: **Counter**, **UpDownCounter**, **ObservableCounter**, and
+    **ObservableUpDownCounter** use **delta** temporality on the OTLP/HTTP metric
+    exporter (short-lived sessions export per-interval increments; backends can sum
+    without a cumulative-to-delta processor). **Histogram** and **ObservableGauge**
+    are omitted so they keep exporter/SDK defaults (cumulative-style behavior for
+    histogram buckets / percentiles).
+
+    Requires optional dependency group ``opentelemetry`` (and HTTP OTLP exporter
+    packages) to be installed.
+
+    Args:
+        enabled: If ``None``, install only when ``DOME_OTEL_EXPORTER_OTLP_ENDPOINT`` is set on
+            *settings* (after env load if *settings* is omitted) or per-signal
+            ``OTEL_EXPORTER_OTLP_*_ENDPOINT`` env vars are set. If ``False``, return ``None``.
+            If ``True``, attempt setup and warn if no endpoint is found.
+        settings: Optional :class:`~.settings.AgentCoreRuntimeSettings`; when omitted, env
+            is loaded once for team/agent ids and ``otel_exporter_otlp_endpoint``
+            (``DOME_OTEL_EXPORTER_OTLP_ENDPOINT``).
+        team_id: Overrides ``team.id`` / ``service.namespace`` when not ``None``.
+        agent_id: Overrides ``agent.id`` when not ``None``.
+        bridge_stdlib_logging: If True, attach an OpenTelemetry ``LoggingHandler`` to
+            *bridge_logger_name* so stdlib logs are emitted as OTel log records.
+        bridge_logger_name: Logger name for the bridge (default ``vijil.dome``).
+
+    Returns:
+        :class:`AgentCoreOtelExporterHandle` to shut down later, or ``None`` if
+        exporters were not installed. If another component already set global SDK
+        providers, returns a handle with ``manages_global_providers`` false so
+        :meth:`~AgentCoreOtelExporterHandle.shutdown` does not replace them.
+    """
+    from .settings import load_agentcore_runtime_settings_from_env
+
+    resolved_settings = settings or load_agentcore_runtime_settings_from_env()
+    if enabled is None:
+        enabled = _has_otlp_endpoint_config(resolved_settings)
+    if not enabled:
+        return None
+
+    if _global_otel_sdk_providers_already_set():
+        logger.info(
+            "AgentCore OTLP exporter setup skipped: an SDK TracerProvider or MeterProvider "
+            "is already configured (e.g. host setup_telemetry). Using existing global "
+            "providers for Dome; handle.shutdown() will not shut down those providers."
+        )
+        return AgentCoreOtelExporterHandle(
+            bridge_handler=None,
+            bridge_logger_name=None,
+            manages_global_providers=False,
+        )
+
+    try:
+        from opentelemetry import metrics, trace
+        from opentelemetry._logs import set_logger_provider
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.instrumentation.logging import LoggingInstrumentor
+        from opentelemetry.sdk import metrics as sdkmetrics
+        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import (
+            AggregationTemporality,
+            PeriodicExportingMetricReader,
+        )
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError as e:
+        logger.warning(
+            "AgentCore OTel exporters skipped (install optional 'opentelemetry' extras): %s",
+            e,
+        )
+        return None
+
+    if not _has_otlp_endpoint_config(resolved_settings):
+        logger.warning(
+            "AgentCore OTLP exporter setup was requested but no Dome OTLP HTTP endpoint was "
+            "found. Set ``DOME_OTEL_EXPORTER_OTLP_ENDPOINT`` (base URL; ``v1/traces``, "
+            "``v1/metrics``, and ``v1/logs`` are appended per signal) and/or per-signal "
+            "``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT``, ``OTEL_EXPORTER_OTLP_METRICS_ENDPOINT``, "
+            "``OTEL_EXPORTER_OTLP_LOGS_ENDPOINT``. Skipping exporter setup."
+        )
+        return None
+
+    resolved_team_id = (
+        (team_id or "").strip()
+        if team_id is not None
+        else resolved_settings.team_id
+    )
+    if agent_id is not None:
+        resolved_agent_id: Optional[str] = agent_id.strip() or None
+    else:
+        resolved_agent_id = resolved_settings.agent_id
+    resource = create_agentcore_otel_resource(resolved_team_id, resolved_agent_id)
+
+    trace_endpoint = _resolved_trace_otlp_endpoint(resolved_settings)
+    metrics_endpoint = _resolved_metrics_otlp_endpoint(resolved_settings)
+    logs_endpoint = _resolved_logs_otlp_endpoint(resolved_settings)
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=trace_endpoint))
+    )
+    trace.set_tracer_provider(tracer_provider)
+
+    # Counter-family instruments use DELTA: each short-lived AgentCore session can
+    # export per-export increments without needing a cumulativetodelta collector
+    # processor. Histograms intentionally omitted — default temporality preserves
+    # bucket snapshots for P50/P90/P95/P99-style percentile workflows.
+    _agentcore_preferred_temporality: dict[type, AggregationTemporality] = {
+        sdkmetrics.Counter: AggregationTemporality.DELTA,
+        sdkmetrics.UpDownCounter: AggregationTemporality.DELTA,
+        sdkmetrics.ObservableCounter: AggregationTemporality.DELTA,
+        sdkmetrics.ObservableUpDownCounter: AggregationTemporality.DELTA,
+    }
+    metric_exporter = OTLPMetricExporter(
+        endpoint=metrics_endpoint,
+        preferred_temporality=_agentcore_preferred_temporality,
+    )
+    reader = PeriodicExportingMetricReader(metric_exporter)
+    meter_provider = MeterProvider(metric_readers=[reader], resource=resource)
+    metrics.set_meter_provider(meter_provider)
+
+    logger_provider = LoggerProvider(resource=resource)
+    logger_provider.add_log_record_processor(
+        BatchLogRecordProcessor(OTLPLogExporter(endpoint=logs_endpoint))
+    )
+    set_logger_provider(logger_provider)
+
+    bridge: Optional[logging.Handler] = None
+    if bridge_stdlib_logging:
+        if not LoggingInstrumentor().is_instrumented_by_opentelemetry:
+            LoggingInstrumentor().instrument(set_logging_format=True)
+        bridge = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
+        logging.getLogger(bridge_logger_name).addHandler(bridge)
+
+    logger.info(
+        "AgentCore OTLP/HTTP exporters initialized (traces, metrics, logs; "
+        "service.name=%s team.id=%s agent.id=%s)",
+        resource.attributes.get("service.name", ""),
+        resource.attributes.get("team.id", ""),
+        resource.attributes.get("agent.id", ""),
+    )
+    return AgentCoreOtelExporterHandle(
+        bridge_handler=bridge,
+        bridge_logger_name=bridge_logger_name if bridge_stdlib_logging else None,
+        manages_global_providers=True,
+    )
+
+
+def setup_agentcore_otel_for_dome(
+    dome: "Dome",
+    *,
+    enabled: Optional[bool] = None,
+    settings: Optional["AgentCoreRuntimeSettings"] = None,
+    team_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    bridge_stdlib_logging: bool = True,
+    bridge_logger_name: str = "vijil.dome",
+) -> Optional[AgentCoreDomeOtelExporterHandle]:
+    """Configure OTLP exporters and attach OpenTelemetry to *dome* in one call.
+
+    Runs :func:`setup_agentcore_otel_exporters_from_env`, then wires
+    :func:`~vijil_dome.integrations.instrumentation.otel_instrumentation.instrument_dome`
+    to the global tracer and meter (and applies log formatters when the stdlib bridge
+    is enabled). Returns ``None`` when :func:`setup_agentcore_otel_exporters_from_env`
+    would return ``None`` (disabled, missing optional dependencies, or no OTLP endpoint
+    when no SDK providers are installed yet).
+
+    If the host runtime already installed global SDK providers (for example
+    ``setup_telemetry(service_name=...)``), exporter setup is skipped without calling
+    ``set_tracer_provider`` / ``set_meter_provider`` again; Dome instrumentation still
+    attaches to the existing providers. The returned handle has
+    ``manages_global_providers`` false so :meth:`~AgentCoreOtelExporterHandle.shutdown`
+    does not tear down the host's providers.
+
+    After S3 reloads that replace guardrails, :meth:`AgentCoreDomeOtelExporterHandle.reinstrument_dome`
+    keeps instrumentation on the new instances. :func:`start_agentcore_background_services`
+    invokes it automatically when you pass this handle and the S3 config poller runs.
+
+    Args:
+        dome: The :class:`~vijil_dome.Dome.Dome` instance to instrument.
+        enabled, settings, team_id, agent_id, bridge_stdlib_logging, bridge_logger_name:
+            Forwarded to :func:`setup_agentcore_otel_exporters_from_env`.
+    """
+    base = setup_agentcore_otel_exporters_from_env(
+        enabled=enabled,
+        settings=settings,
+        team_id=team_id,
+        agent_id=agent_id,
+        bridge_stdlib_logging=bridge_stdlib_logging,
+        bridge_logger_name=bridge_logger_name,
+    )
+    if base is None:
+        return None
+    _apply_dome_otel_instrumentation(
+        dome,
+        bridge_stdlib_logging=bridge_stdlib_logging,
+        bridge_logger_name=bridge_logger_name,
+    )
+    return AgentCoreDomeOtelExporterHandle(
+        bridge_handler=base.bridge_handler,
+        bridge_logger_name=base.bridge_logger_name,
+        attach_stdlib_log_formatting=bridge_stdlib_logging,
+        use_bridge_logger_name=bridge_logger_name,
+        manages_global_providers=base.manages_global_providers,
+    )

--- a/vijil_dome/integrations/agentcore/otel_lifecycle.py
+++ b/vijil_dome/integrations/agentcore/otel_lifecycle.py
@@ -1,0 +1,56 @@
+# Copyright 2025 Vijil, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Graceful shutdown for global OpenTelemetry SDK providers (metrics export threads, etc.)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("vijil.dome")
+
+
+def shutdown_opentelemetry_providers() -> None:
+    """Shut down global TracerProvider, MeterProvider, and LoggerProvider if they expose ``shutdown``.
+
+    Safe to call when OpenTelemetry is not installed or only the no-op API is
+    registered. Intended to be invoked from application shutdown paths (for
+    example after stopping other background threads) so batch exporters flush.
+    """
+    try:
+        from opentelemetry import metrics, trace
+    except ImportError:
+        logger.debug("OpenTelemetry not installed; skipping provider shutdown")
+        return
+
+    _shutdown_if_supported("TracerProvider", trace.get_tracer_provider())
+    _shutdown_if_supported("MeterProvider", metrics.get_meter_provider())
+
+    try:
+        from opentelemetry._logs import get_logger_provider
+    except ImportError:
+        return
+    _shutdown_if_supported("LoggerProvider", get_logger_provider())
+
+
+def _shutdown_if_supported(kind: str, provider: Any) -> None:
+    shutdown = getattr(provider, "shutdown", None)
+    if shutdown is None:
+        return
+    try:
+        shutdown()
+        logger.info("Shut down OpenTelemetry %s", kind)
+    except Exception:
+        logger.exception("Error while shutting down OpenTelemetry %s", kind)

--- a/vijil_dome/integrations/agentcore/settings.py
+++ b/vijil_dome/integrations/agentcore/settings.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Vijil, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment-driven settings for AgentCore-friendly Dome runtime helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+def _env_opt_str(name: str) -> Optional[str]:
+    v = os.environ.get(name, "").strip()
+    return v or None
+
+
+@dataclass(frozen=True)
+class AgentCoreRuntimeSettings:
+    """Identifiers and Dome-specific OTLP base URL for AgentCore helpers."""
+
+    team_id: str = ""
+    """From ``TEAM_ID``; used for OTel resource and S3 config key (with ``agent_id``)."""
+
+    agent_id: Optional[str] = None
+    """From ``AGENT_ID``; ``agent.id`` on the OTel resource and S3 key segment."""
+
+    s3_config_bucket: Optional[str] = None
+    """From ``DOME_CONFIG_S3_BUCKET``; with ``team_id`` and ``agent_id``, enables settings-based S3 polling."""
+
+    otel_exporter_otlp_endpoint: Optional[str] = None
+    """From ``DOME_OTEL_EXPORTER_OTLP_ENDPOINT``; OTLP/HTTP base for Dome exporters (paths appended per signal)."""
+
+
+def load_agentcore_runtime_settings_from_env() -> AgentCoreRuntimeSettings:
+    """Load :class:`AgentCoreRuntimeSettings` from environment variables.
+
+    Variables (all optional):
+
+    - ``TEAM_ID`` / ``AGENT_ID`` — ``team.id`` / ``agent.id`` for OTel and the
+      standard S3 object key ``teams/{team}/agents/{agent}/dome/config.json`` when polling
+      without :meth:`~vijil_dome.Dome.Dome.create_from_s3`.
+    - ``DOME_CONFIG_S3_BUCKET`` — bucket for that key when not using ``create_from_s3``.
+      Together with non-empty ``TEAM_ID`` and ``AGENT_ID``, this enables the S3 config poller
+      in :func:`~.background.start_agentcore_background_services`.
+    - ``DOME_OTEL_EXPORTER_OTLP_ENDPOINT`` — Dome OTLP/HTTP base URL (avoids the host-wide
+      ``OTEL_EXPORTER_OTLP_ENDPOINT``). Paths ``v1/traces`` / ``v1/metrics`` / ``v1/logs`` are
+      appended unless you set per-signal ``OTEL_EXPORTER_OTLP_*_ENDPOINT`` in the environment
+      (see :func:`~.otel_exporters.setup_agentcore_otel_exporters_from_env`).
+    """
+    return AgentCoreRuntimeSettings(
+        team_id=os.getenv("TEAM_ID", "").strip(),
+        agent_id=_env_opt_str("AGENT_ID"),
+        s3_config_bucket=_env_opt_str("DOME_CONFIG_S3_BUCKET"),
+        otel_exporter_otlp_endpoint=_env_opt_str("DOME_OTEL_EXPORTER_OTLP_ENDPOINT"),
+    )

--- a/vijil_dome/tests/integrations/test_agentcore_background.py
+++ b/vijil_dome/tests/integrations/test_agentcore_background.py
@@ -1,0 +1,247 @@
+# Copyright 2025 Vijil, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import json
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vijil_dome import Dome
+from vijil_dome.integrations.agentcore import (
+    AgentCoreOtelExporterHandle,
+    AgentCoreRuntimeSettings,
+    combine_agentcore_s3_reload_callbacks,
+    DomeS3ConfigPoller,
+    load_agentcore_runtime_settings_from_env,
+    start_agentcore_background_services,
+)
+from vijil_dome.utils.config_loader import build_s3_config_key
+
+SAMPLE_CONFIG = {
+    "input-guards": [
+        {
+            "security_min": {
+                "type": "security",
+                "methods": ["encoding-heuristics"],
+            }
+        }
+    ],
+    "output-guards": [],
+}
+
+BUCKET = "b"
+TEAM_ID = "t"
+AGENT_ID = "a"
+
+
+@patch("vijil_dome.utils.config_loader._create_s3_client")
+def test_dome_reload_from_s3_if_changed(mock_create_client, tmp_path):
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+    mock_client.get_object.return_value = {
+        "Body": io.BytesIO(json.dumps(SAMPLE_CONFIG).encode()),
+        "ETag": '"e1"',
+    }
+    dome = Dome.create_from_s3(
+        BUCKET, team_id=TEAM_ID, agent_id=AGENT_ID, cache_dir=str(tmp_path)
+    )
+    mock_client.get_object.return_value = {
+        "Body": io.BytesIO(json.dumps(SAMPLE_CONFIG).encode()),
+        "ETag": '"e2"',
+    }
+    assert dome.reload_from_s3_if_changed() is False
+
+    new_cfg = {**SAMPLE_CONFIG, "id": "new-id"}
+    mock_client.get_object.return_value = {
+        "Body": io.BytesIO(json.dumps(new_cfg).encode()),
+        "ETag": '"e3"',
+    }
+    assert dome.reload_from_s3_if_changed() is True
+    assert dome.config_id == "new-id"
+
+
+def test_load_agentcore_runtime_settings_from_env(monkeypatch):
+    s = load_agentcore_runtime_settings_from_env()
+    assert s.team_id == ""
+    assert s.agent_id is None
+    assert s.s3_config_bucket is None
+    assert s.otel_exporter_otlp_endpoint is None
+
+    monkeypatch.setenv("TEAM_ID", " team-x ")
+    monkeypatch.setenv("AGENT_ID", " agent-y ")
+    monkeypatch.setenv("DOME_CONFIG_S3_BUCKET", "my-bucket")
+    monkeypatch.setenv("DOME_OTEL_EXPORTER_OTLP_ENDPOINT", " http://collector:4318 ")
+    s2 = load_agentcore_runtime_settings_from_env()
+    assert s2.team_id == "team-x"
+    assert s2.agent_id == "agent-y"
+    assert s2.s3_config_bucket == "my-bucket"
+    assert s2.otel_exporter_otlp_endpoint == "http://collector:4318"
+
+
+@patch("vijil_dome.utils.config_loader._create_s3_client")
+def test_s3_poller_stop_joins_thread(mock_create_client, tmp_path):
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+    mock_client.get_object.return_value = {
+        "Body": io.BytesIO(json.dumps(SAMPLE_CONFIG).encode()),
+        "ETag": '"e1"',
+    }
+    dome = Dome.create_from_s3(
+        BUCKET, team_id=TEAM_ID, agent_id=AGENT_ID, cache_dir=str(tmp_path)
+    )
+    poller = DomeS3ConfigPoller(
+        dome, AgentCoreRuntimeSettings(), interval_seconds=0.05
+    )
+    poller.start()
+    assert poller.is_running
+    deadline = time.time() + 2.0
+    while not mock_client.get_object.called and time.time() < deadline:
+        time.sleep(0.01)
+    poller.stop(join_timeout=5.0)
+    assert not poller.is_running
+
+
+def test_start_agentcore_background_services_no_poll_without_s3_metadata():
+    dome = Dome(SAMPLE_CONFIG)
+    bg = start_agentcore_background_services(
+        dome,
+        settings=AgentCoreRuntimeSettings(),
+    )
+    assert bg._poller is None
+    bg.shutdown()
+
+
+@patch("vijil_dome.utils.config_loader._create_s3_client")
+def test_start_agentcore_starts_poller_when_enabled(mock_create_client, tmp_path):
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+    mock_client.get_object.return_value = {
+        "Body": io.BytesIO(json.dumps(SAMPLE_CONFIG).encode()),
+        "ETag": '"e1"',
+    }
+    dome = Dome.create_from_s3(
+        BUCKET, team_id=TEAM_ID, agent_id=AGENT_ID, cache_dir=str(tmp_path)
+    )
+    bg = start_agentcore_background_services(
+        dome,
+        settings=AgentCoreRuntimeSettings(),
+        poll_interval_seconds=30.0,
+    )
+    assert bg._poller is not None
+    assert bg._poller.is_running
+    bg.shutdown(join_timeout=5.0)
+    assert not bg._poller.is_running
+
+
+def test_poller_start_raises_without_s3_coordinates():
+    dome = Dome(SAMPLE_CONFIG)
+    poller = DomeS3ConfigPoller(
+        dome, AgentCoreRuntimeSettings(), interval_seconds=1.0
+    )
+    with pytest.raises(ValueError, match="DomeS3ConfigPoller requires"):
+        poller.start()
+
+
+def test_start_agentcore_no_poller_when_settings_missing_agent():
+    dome = Dome(SAMPLE_CONFIG)
+    bg = start_agentcore_background_services(
+        dome,
+        settings=AgentCoreRuntimeSettings(
+            s3_config_bucket="b",
+            team_id="t",
+            agent_id=None,
+        ),
+    )
+    assert bg._poller is None
+    bg.shutdown()
+
+
+@patch("vijil_dome.integrations.agentcore.background.load_dome_config_from_s3")
+def test_poller_settings_mode_applies_remote_config(mock_load):
+    mock_load.side_effect = [
+        {**SAMPLE_CONFIG, "id": "id1"},
+        {**SAMPLE_CONFIG, "id": "id2"},
+    ]
+    dome = Dome(SAMPLE_CONFIG)
+    settings = AgentCoreRuntimeSettings(
+        s3_config_bucket="my-bucket",
+        team_id="t",
+        agent_id="a",
+    )
+    poller = DomeS3ConfigPoller(dome, settings, interval_seconds=0.05)
+    poller.start()
+    deadline = time.time() + 3.0
+    while dome.config_id != "id1" and time.time() < deadline:
+        time.sleep(0.02)
+    assert dome.config_id == "id1"
+    mock_load.assert_called_with(
+        bucket="my-bucket",
+        key=build_s3_config_key("t", "a"),
+        cache_ttl_seconds=0,
+    )
+    deadline = time.time() + 3.0
+    while dome.config_id != "id2" and time.time() < deadline:
+        time.sleep(0.02)
+    assert dome.config_id == "id2"
+    poller.stop(join_timeout=5.0)
+
+
+def test_combine_agentcore_s3_reload_callbacks_runs_otel_then_user():
+    order = []
+    handle = MagicMock()
+    handle.reinstrument_dome = lambda d: order.append("otel")
+
+    def user(d):
+        order.append("user")
+
+    merged = combine_agentcore_s3_reload_callbacks(
+        otel_exporter_handle=handle,
+        on_s3_reload=user,
+    )
+    assert merged is not None
+    dome = MagicMock()
+    merged(dome)
+    assert order == ["otel", "user"]
+
+
+def test_combine_agentcore_s3_reload_callbacks_plain_handle_delegates_user_only():
+    order = []
+    plain = AgentCoreOtelExporterHandle()
+
+    def user(d):
+        order.append("user")
+
+    merged = combine_agentcore_s3_reload_callbacks(
+        otel_exporter_handle=plain,
+        on_s3_reload=user,
+    )
+    assert merged is user
+    merged(MagicMock())
+    assert order == ["user"]
+
+
+def test_combine_agentcore_s3_reload_callbacks_reinstrument_only():
+    order = []
+    handle = MagicMock()
+    handle.reinstrument_dome = lambda d: order.append("otel")
+    merged = combine_agentcore_s3_reload_callbacks(
+        otel_exporter_handle=handle,
+        on_s3_reload=None,
+    )
+    assert merged is not None
+    merged(MagicMock())
+    assert order == ["otel"]

--- a/vijil_dome/tests/integrations/test_agentcore_otel_exporters.py
+++ b/vijil_dome/tests/integrations/test_agentcore_otel_exporters.py
@@ -1,0 +1,235 @@
+# Copyright 2025 Vijil, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vijil_dome import Dome
+from vijil_dome.integrations.agentcore import (
+    AgentCoreRuntimeSettings,
+    start_agentcore_background_services,
+)
+from vijil_dome.integrations.agentcore.otel_exporters import (
+    setup_agentcore_otel_exporters_from_env,
+    setup_agentcore_otel_for_dome,
+)
+
+
+def test_setup_otel_exporters_explicit_disabled():
+    pytest.importorskip("opentelemetry.sdk.trace")
+    assert setup_agentcore_otel_exporters_from_env(enabled=False) is None
+
+
+def test_setup_otel_exporters_enabled_missing_endpoint_returns_none(monkeypatch):
+    pytest.importorskip("opentelemetry.sdk.trace")
+    for k in (
+        "DOME_OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    assert (
+        setup_agentcore_otel_exporters_from_env(
+            enabled=True,
+            settings=AgentCoreRuntimeSettings(),
+        )
+        is None
+    )
+
+
+def test_create_agentcore_otel_resource():
+    pytest.importorskip("opentelemetry.sdk.resources")
+    from vijil_dome.integrations.agentcore.otel_exporters import create_agentcore_otel_resource
+
+    r = create_agentcore_otel_resource("team-1", "agent-1")
+    assert r.attributes["service.name"] == "vijil.dome"
+    assert r.attributes["service.namespace"] == "team-1"
+    assert r.attributes["team.id"] == "team-1"
+    assert r.attributes["agent.id"] == "agent-1"
+    r2 = create_agentcore_otel_resource("t2", None)
+    assert r2.attributes.get("agent.id") is None
+
+
+def test_setup_otel_uses_settings_for_team_agent(monkeypatch):
+    pytest.importorskip("opentelemetry.sdk.trace")
+    pytest.importorskip("opentelemetry.instrumentation.logging")
+    for k in (
+        "DOME_OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "1")
+    monkeypatch.delenv("TEAM_ID", raising=False)
+    monkeypatch.delenv("AGENT_ID", raising=False)
+
+    settings = AgentCoreRuntimeSettings(
+        team_id="from-settings",
+        agent_id="agent-s",
+        otel_exporter_otlp_endpoint="http://127.0.0.1:4318",
+    )
+    handle = setup_agentcore_otel_exporters_from_env(
+        settings=settings,
+        bridge_stdlib_logging=False,
+    )
+    assert handle is not None
+
+    from opentelemetry import trace
+
+    tp = trace.get_tracer_provider()
+    assert tp.resource.attributes.get("team.id") == "from-settings"
+    assert tp.resource.attributes.get("agent.id") == "agent-s"
+
+    handle.shutdown()
+
+
+def test_setup_otel_exporters_inits_providers(monkeypatch):
+    pytest.importorskip("opentelemetry.sdk.trace")
+    pytest.importorskip("opentelemetry.instrumentation.logging")
+    monkeypatch.setenv("DOME_OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "1")
+    monkeypatch.setenv("TEAM_ID", "t-res")
+    monkeypatch.delenv("AGENT_ID", raising=False)
+
+    handle = setup_agentcore_otel_exporters_from_env(
+        bridge_stdlib_logging=False, team_id="override-team", agent_id="a1"
+    )
+    assert handle is not None
+
+    from opentelemetry import metrics, trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    assert isinstance(trace.get_tracer_provider(), TracerProvider)
+    mp = metrics.get_meter_provider()
+    assert hasattr(mp, "shutdown")
+    tp = trace.get_tracer_provider()
+    assert tp.resource.attributes.get("team.id") == "override-team"
+    assert tp.resource.attributes.get("agent.id") == "a1"
+
+    handle.shutdown()
+
+
+SAMPLE_DOME_CFG = {
+    "input-guards": [
+        {"g": {"type": "security", "methods": ["encoding-heuristics"]}}
+    ],
+    "output-guards": [],
+}
+
+
+def test_setup_agentcore_otel_for_dome_instruments_and_reinstrument(monkeypatch):
+    pytest.importorskip("opentelemetry.sdk.trace")
+    pytest.importorskip("opentelemetry.instrumentation.logging")
+    monkeypatch.setenv("DOME_OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "1")
+
+    dome = Dome(SAMPLE_DOME_CFG)
+    handle = setup_agentcore_otel_for_dome(
+        dome,
+        bridge_stdlib_logging=False,
+        team_id="t1",
+        agent_id="a1",
+    )
+    assert handle is not None
+    assert hasattr(handle, "reinstrument_dome")
+    handle.reinstrument_dome(dome)
+    handle.shutdown()
+
+
+def test_setup_skips_global_providers_when_tracer_already_configured(monkeypatch):
+    pytest.importorskip("opentelemetry.sdk.trace")
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    from vijil_dome.integrations.agentcore.otel_lifecycle import (
+        shutdown_opentelemetry_providers,
+    )
+
+    trace.set_tracer_provider(TracerProvider())
+    try:
+        handle = setup_agentcore_otel_exporters_from_env(
+            enabled=True,
+            settings=AgentCoreRuntimeSettings(),
+            bridge_stdlib_logging=False,
+        )
+        assert handle is not None
+        assert handle.manages_global_providers is False
+        spy = MagicMock()
+        monkeypatch.setattr(
+            "vijil_dome.integrations.agentcore.otel_lifecycle.shutdown_opentelemetry_providers",
+            spy,
+        )
+        handle.shutdown()
+        spy.assert_not_called()
+    finally:
+        shutdown_opentelemetry_providers()
+
+
+def test_setup_agentcore_otel_for_dome_after_host_telemetry(monkeypatch):
+    pytest.importorskip("opentelemetry.sdk.trace")
+    pytest.importorskip("opentelemetry.instrumentation.logging")
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    from vijil_dome.integrations.agentcore.otel_lifecycle import (
+        shutdown_opentelemetry_providers,
+    )
+
+    trace.set_tracer_provider(TracerProvider())
+    try:
+        dome = Dome(SAMPLE_DOME_CFG)
+        handle = setup_agentcore_otel_for_dome(
+            dome,
+            enabled=True,
+            settings=AgentCoreRuntimeSettings(),
+            bridge_stdlib_logging=False,
+        )
+        assert handle is not None
+        assert handle.manages_global_providers is False
+        spy = MagicMock()
+        monkeypatch.setattr(
+            "vijil_dome.integrations.agentcore.otel_lifecycle.shutdown_opentelemetry_providers",
+            spy,
+        )
+        handle.shutdown()
+        spy.assert_not_called()
+    finally:
+        shutdown_opentelemetry_providers()
+
+
+def test_background_shutdown_prefers_otel_handle():
+    pytest.importorskip("opentelemetry.sdk.trace")
+    handle = MagicMock()
+
+    cfg = {
+        "input-guards": [
+            {"g": {"type": "security", "methods": ["encoding-heuristics"]}}
+        ],
+        "output-guards": [],
+    }
+    dome = Dome(cfg)
+
+    spy = MagicMock(wraps=handle)
+    bg = start_agentcore_background_services(
+        dome,
+        settings=AgentCoreRuntimeSettings(),
+        otel_exporter_handle=spy,
+    )
+    bg.shutdown()
+    spy.shutdown.assert_called_once()


### PR DESCRIPTION
Add vijil_dome.integrations.agentcore for long-lived agents: optional S3 Dome config reload, OTLP/HTTP trace+metric+log exporters, coordinated shutdown, and OTel provider lifecycle helpers.

Dome gains reload_from_s3_if_changed, apply_config_dict, and _equivalent_s3_configs so the poller can detect remote changes consistently with config_has_changed.

Runtime settings read TEAM_ID, AGENT_ID, DOME_CONFIG_S3_BUCKET, and DOME_OTEL_EXPORTER_OTLP_ENDPOINT only. S3 polling starts when the Dome was created with create_from_s3 (S3 metadata present) or when bucket, team_id, and agent_id are all set; poll interval defaults to 300s (poll_interval_seconds on start_agentcore_background_services for tests). OTLP setup uses the Dome endpoint env var so it does not consume the host OTEL_EXPORTER_OTLP_ENDPOINT; with enabled=None, exporters install when that base URL or per-signal OTLP endpoints exist.

Update docs/AGENTS.md, agentcore README, integration tests, and otel_identity_smoke_test.