### PR TITLE
ci(dome): allow OPENAI_API_BASE override via secret for Dependabot CI

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -89,6 +89,7 @@ jobs:
         env:
           VIJIL_MODEL_DIR: /models
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
           TOGETHERAI_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           PERSPECTIVE_API_KEY: ${{ secrets.PERSPECTIVE_API_KEY }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}` to the test step's env block in `.github/workflows/python-app.yaml`.
- Unblocks Dependabot PRs (#195, #197, #199, #222, #226, #231) whose CI was failing on 8 LLM-detector tests because Dependabot-triggered workflows can't read Actions secrets, and the OpenAI-compatible DO Inference key needs its own endpoint to be honored.
- Pure secret indirection — no behavior change on `main` (Actions secret store has no `OPENAI_API_BASE`, so the var resolves to empty and litellm/openai use the default `api.openai.com`).

## Context

GitHub silos Dependabot secrets from Actions secrets, so Dependabot-triggered runs see `${{ secrets.OPENAI_API_KEY }}` as empty. We mirrored the secret to the Dependabot store (using the team's DO Inference key, which exposes an OpenAI-compatible API), but `litellm.acompletion(...)` still hits `api.openai.com` by default — and the DO key is invalid against OpenAI directly. This one-line workflow change lets us also mirror an endpoint override into the Dependabot store, routing those calls to `https://inference.do-ai.run/v1`.

Same upcoming session also identified two genuinely dead workflow env entries — `TOGETHER_API_KEY` (wrong variable name; code reads `TOGETHERAI_API_KEY`, no test exercises Together) and `PERSPECTIVE_API_KEY` (all Perspective tests are commented out in `test_moderations_detectors.py`). Leaving those for a separate cleanup PR to keep this change scoped.

## Test plan

- [ ] CI run on this PR is green (uses `main`'s old workflow with the Actions OpenAI key + default endpoint — should be unchanged).
- [ ] After merge, rerun the 6 stuck Dependabot PRs and confirm they go green.