### PR TITLE
ci(dome): route LLM-detector tests through DO Inference on Dependabot

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -89,11 +89,23 @@ jobs:
         env:
           VIJIL_MODEL_DIR: /models
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
-          VIJIL_LLM_MODEL: ${{ secrets.VIJIL_LLM_MODEL }}
+          OPENAI_BASE_URL_SECRET: ${{ secrets.OPENAI_BASE_URL }}
+          VIJIL_LLM_MODEL_SECRET: ${{ secrets.VIJIL_LLM_MODEL }}
           TOGETHERAI_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           PERSPECTIVE_API_KEY: ${{ secrets.PERSPECTIVE_API_KEY }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
         run: |
+          # Only export OPENAI_BASE_URL / VIJIL_LLM_MODEL when the matching
+          # secret is non-empty. Binding them directly via the env block sets
+          # them to "" when the secret is unset (Actions store has no such
+          # key on non-Dependabot runs), and openai-python treats "" as a
+          # literal empty base URL rather than "use default" — producing
+          # APIConnectionError on the moderations endpoint.
+          if [ -n "$OPENAI_BASE_URL_SECRET" ]; then
+            export OPENAI_BASE_URL="$OPENAI_BASE_URL_SECRET"
+          fi
+          if [ -n "$VIJIL_LLM_MODEL_SECRET" ]; then
+            export VIJIL_LLM_MODEL="$VIJIL_LLM_MODEL_SECRET"
+          fi
           export PYTHONPATH=$PWD
           make test

--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -89,7 +89,8 @@ jobs:
         env:
           VIJIL_MODEL_DIR: /models
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+          VIJIL_LLM_MODEL: ${{ secrets.VIJIL_LLM_MODEL }}
           TOGETHERAI_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           PERSPECTIVE_API_KEY: ${{ secrets.PERSPECTIVE_API_KEY }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}

--- a/docs/ci/do-inference-models.md
+++ b/docs/ci/do-inference-models.md
@@ -1,0 +1,119 @@
+# DigitalOcean Inference — Model Catalog
+
+CI for Dependabot PRs routes LLM-detector calls through DigitalOcean
+Inference (`https://inference.do-ai.run/v1`) because the real OpenAI
+secret is in the Actions secret store and GitHub silos that store from
+Dependabot-triggered runs. This file is the model catalog we resolve
+against without re-querying DO each CI run.
+
+## How CI uses this
+
+Three GitHub Actions secrets in the **Dependabot store** (not Actions):
+
+| Secret | Value |
+|---|---|
+| `OPENAI_API_KEY` | DO API key (`sk-do-…`) — OpenAI-compatible auth |
+| `OPENAI_BASE_URL` | `https://inference.do-ai.run/v1` |
+| `VIJIL_LLM_MODEL` | A DO model id from the catalog below, prefixed `openai/` so litellm routes through the OpenAI hub (e.g. `openai/openai-gpt-4o-mini`) |
+
+`vijil_dome/defaults.py` reads `VIJIL_LLM_MODEL`; `LlmBaseDetector`
+(`vijil_dome/detectors/utils/llm_api_base.py`) reads `OPENAI_BASE_URL`
+for the `openai` hub. Both fall back to existing defaults when unset,
+so main-branch CI and library consumers behave identically to before.
+
+## Refreshing this list
+
+```bash
+curl -s "https://inference.do-ai.run/v1/models" \
+  -H "Authorization: Bearer $DO_API_KEY" \
+  | jq -r '.data | sort_by(.id) | .[] | "\(.id)\t\(.owned_by)"'
+```
+
+`/v1/models` does not include embedding-only models reliably; see
+the team's separate notes on DO Inference embeddings.
+
+## Catalog (snapshot: 2026-05-28)
+
+### OpenAI-owned (proxied)
+
+OpenAI-compatible request shape; use these when the Dome test exercises
+an OpenAI-style chat completion path.
+
+| Model id | Notes |
+|---|---|
+| `openai-gpt-4o` | |
+| `openai-gpt-4o-mini` | **CI default — cheap, fast, sufficient for binary-classifier prompts** |
+| `openai-gpt-4.1` | |
+| `openai-gpt-5` | |
+| `openai-gpt-5-mini` | |
+| `openai-gpt-5-nano` | |
+| `openai-gpt-5.1-codex-max` | |
+| `openai-gpt-5.2` / `openai-gpt-5.2-pro` | |
+| `openai-gpt-5.3-codex` | Self-truncates on long contexts per team notes |
+| `openai-gpt-5.4` / `openai-gpt-5.4-mini` / `openai-gpt-5.4-nano` / `openai-gpt-5.4-pro` | |
+| `openai-gpt-5.5` | |
+| `openai-o1` / `openai-o3` / `openai-o3-mini` | Reasoning models |
+| `openai-gpt-image-1` / `openai-gpt-image-1.5` / `openai-gpt-image-2` | Image generation, not chat |
+
+### Anthropic-owned (proxied)
+
+| Model id |
+|---|
+| `anthropic-claude-4.1-opus` |
+| `anthropic-claude-4.5-sonnet` |
+| `anthropic-claude-4.6-sonnet` |
+| `anthropic-claude-haiku-4.5` |
+| `anthropic-claude-opus-4` |
+| `anthropic-claude-opus-4.5` |
+| `anthropic-claude-opus-4.6` |
+| `anthropic-claude-opus-4.7` |
+| `anthropic-claude-sonnet-4` |
+
+### DigitalOcean-hosted (open-weight + DO-original)
+
+| Model id | Notes |
+|---|---|
+| `alibaba-qwen3-32b` | |
+| `arcee-trinity-large-thinking` | |
+| `deepseek-3.2` / `deepseek-4-flash` / `deepseek-v4-pro` | |
+| `deepseek-r1-distill-llama-70b` | |
+| `gemma-4-31B-it` | |
+| `glm-5` | |
+| `kimi-k2.5` / `kimi-k2.6` | |
+| `llama-4-maverick` | |
+| `llama3.3-70b-instruct` | |
+| `minimax-m2.5` | |
+| `mistral-3-14B` | |
+| `nemotron-3-nano-omni` | |
+| `nemotron-nano-12b-v2-vl` | |
+| `nvidia-nemotron-3-super-120b` | |
+| `openai-gpt-oss-120b` / `openai-gpt-oss-20b` | DO's open-weight OSS Safeguard fork lives here |
+| `qwen3-coder-flash` | |
+| `qwen3.5-397b-a17b` | |
+
+### Embedding / reranker / image / video
+
+Not chat models. Listed for reference; tests that need these should
+configure them separately.
+
+| Model id | Type |
+|---|---|
+| `all-mini-lm-l6-v2` | Embedding |
+| `bge-m3` | Embedding |
+| `bge-reranker-v2-m3` | Reranker |
+| `e5-large-v2` | Embedding |
+| `gte-large-en-v1.5` | Embedding (referenced in team's DO embeddings notes) |
+| `multi-qa-mpnet-base-dot-v1` | Embedding |
+| `qwen3-embedding-0.6b` | Embedding |
+| `qwen3-tts-voicedesign` | TTS |
+| `stable-diffusion-3.5-large` | Image |
+| `wan2-2-t2v-a14b` | Video |
+
+### Routers
+
+| Router id |
+|---|
+| `router:general` |
+| `router:knowledge-base-document` |
+| `router:software-engineering` |
+| `router:writing` |

--- a/vijil_dome/defaults.py
+++ b/vijil_dome/defaults.py
@@ -54,8 +54,8 @@ def get_default_config():
     return DefaultDomeConfig().default_guardrail_config
 
 
-DEFAULT_LLM_MODEL: str = os.environ.get("VIJIL_LLM_MODEL", "gpt-4-turbo")
-DEFAULT_LLM_HUB: str = os.environ.get("VIJIL_LLM_HUB", "openai")
-DEFAULT_SAFEGUARD_MODEL: str = os.environ.get(
-    "VIJIL_SAFEGUARD_MODEL", "openai/gpt-oss-safeguard-20b"
+DEFAULT_LLM_MODEL: str = os.environ.get("VIJIL_LLM_MODEL") or "gpt-4-turbo"
+DEFAULT_LLM_HUB: str = os.environ.get("VIJIL_LLM_HUB") or "openai"
+DEFAULT_SAFEGUARD_MODEL: str = (
+    os.environ.get("VIJIL_SAFEGUARD_MODEL") or "openai/gpt-oss-safeguard-20b"
 )

--- a/vijil_dome/detectors/utils/llm_api_base.py
+++ b/vijil_dome/detectors/utils/llm_api_base.py
@@ -59,7 +59,7 @@ class LlmBaseDetector(DetectionMethod, ABC):
             if api_key is None:
                 api_key = os.getenv("GROQ_API_KEY")
         else:
-            self.base_url = ""
+            self.base_url = os.getenv("OPENAI_BASE_URL", "")
         self.api_key = api_key
         self.timeout = timeout
         self.max_retries = max_retries


### PR DESCRIPTION
## Summary

Unblock the 6 Dependabot PRs (#195, #197, #199, #222, #226, #231) by routing LLM-detector tests through DigitalOcean Inference, which exposes an OpenAI-compatible API and is the only LLM endpoint we have a key for in the Dependabot secret store.

- `vijil_dome/detectors/utils/llm_api_base.py` — `LlmBaseDetector` reads `OPENAI_BASE_URL` from env when `hub_name="openai"` instead of hard-coding `base_url=""`. Empty/unset preserves the existing OpenAI default endpoint.
- `vijil_dome/defaults.py` — `os.environ.get(name, default)` → `os.environ.get(name) or default`. An empty env var (workflow resolving an unset secret to `""`) now falls through to the existing default instead of overriding it to empty string.
- `.github/workflows/python-app.yaml` — exposes `OPENAI_BASE_URL` and `VIJIL_LLM_MODEL` from secrets. The Actions secret store has neither, so main-branch CI continues to use `api.openai.com` + `gpt-4-turbo` exactly as before.
- `docs/ci/do-inference-models.md` — DO Inference model catalog snapshot (65 models, 2026-05-28) so we don't re-query `/v1/models` each CI run, plus the CI default and secret wiring.

## Why this is needed

PR #233 mirrored the DO Inference key to the Dependabot store as `OPENAI_API_KEY`. The reruns still failed with `401 Incorrect API key provided` because two gaps remained:

1. The `openai` hub in `LlmBaseDetector` hard-coded `self.base_url = ""`, overriding any `OPENAI_BASE_URL` env var. The DO key was sent to `api.openai.com`.
2. The default model (`gpt-4-turbo`) is not in DO Inference's catalog. The substitution would have failed on model-not-found even after fixing (1).

Smoke-tested `openai-gpt-4o-mini` against DO's chat completions with the exact prompt from `test_generic_llm_detector` — returns `UNSAFE` for "I really love pecorino" as expected.

## Test plan

- [ ] CI on this PR is green (uses `main`'s old code with real OpenAI key + default endpoint — unchanged path).
- [ ] After merge, rerun #195, #197, #199, #222, #226, #231 and confirm test step turns green.
- [ ] Confirm `main` CI on the next push to main is still green (the new env vars resolve to empty in the Actions store, falling through to existing defaults).

## Dependabot secrets now in place

| Secret | Value |
|---|---|
| `HUGGINGFACE_TOKEN` | same as Actions store |
| `OPENAI_API_KEY` | DO API key (`sk-do-…`) |
| `OPENAI_BASE_URL` | `https://inference.do-ai.run/v1` |
| `VIJIL_LLM_MODEL` | `openai/openai-gpt-4o-mini` |

`TOGETHER_API_KEY` and `PERSPECTIVE_API_KEY` workflow entries are dead (zero tests exercise them; `TOGETHER_API_KEY` is even the wrong variable name — code reads `TOGETHERAI_API_KEY`). Leaving those for a separate cleanup PR.