### PR TITLE
test(dome): env-aware defaults assertion + skip OpenAI moderation when routed away from OpenAI

### DIFF
--- a/vijil_dome/tests/detectors/test_moderations_detectors.py
+++ b/vijil_dome/tests/detectors/test_moderations_detectors.py
@@ -109,6 +109,12 @@ async def test_moderation_detection():
     assert result.hit
 
 
+@pytest.mark.skipif(
+    bool(os.environ.get("OPENAI_BASE_URL")),
+    reason="OpenAI moderations endpoint is only available on OpenAI's own infrastructure; "
+    "OpenAI-compatible providers (e.g. DigitalOcean Inference used in Dependabot CI) "
+    "do not proxy /v1/moderations.",
+)
 @pytest.mark.asyncio
 async def test_moderation_detection_openai():
     # OpenAI Moderation

--- a/vijil_dome/tests/test_defaults.py
+++ b/vijil_dome/tests/test_defaults.py
@@ -9,15 +9,21 @@ class TestCentralizedConstants:
     """Model/hub defaults should be centralized and overridable."""
 
     def test_defaults_module_has_constants(self) -> None:
+        import os
         from vijil_dome.defaults import (
             DEFAULT_LLM_HUB,
             DEFAULT_LLM_MODEL,
             DEFAULT_SAFEGUARD_MODEL,
         )
 
-        assert DEFAULT_LLM_MODEL == "gpt-4-turbo"
-        assert DEFAULT_LLM_HUB == "openai"
-        assert "safeguard" in DEFAULT_SAFEGUARD_MODEL
+        expected_model = os.environ.get("VIJIL_LLM_MODEL") or "gpt-4-turbo"
+        expected_hub = os.environ.get("VIJIL_LLM_HUB") or "openai"
+        expected_safeguard = (
+            os.environ.get("VIJIL_SAFEGUARD_MODEL") or "openai/gpt-oss-safeguard-20b"
+        )
+        assert DEFAULT_LLM_MODEL == expected_model
+        assert DEFAULT_LLM_HUB == expected_hub
+        assert DEFAULT_SAFEGUARD_MODEL == expected_safeguard
 
     def test_llm_detectors_use_default_constant(self) -> None:
         """LLM detector __init__ defaults should reference centralized constants."""


### PR DESCRIPTION
## Summary

Follow-up to #234 — two pre-existing tests didn't anticipate the Dependabot-CI routing through DigitalOcean Inference.

- `tests/test_defaults.py::test_defaults_module_has_constants` hard-coded `assert DEFAULT_LLM_MODEL == \"gpt-4-turbo\"` even though `defaults.py` reads `VIJIL_LLM_MODEL` from env. The assertion now compares to `os.environ.get(name) or <fallback>`, matching the defaults module's own contract.
- `tests/detectors/test_moderations_detectors.py::test_moderation_detection_openai` hits OpenAI's `/v1/moderations`, which OpenAI-compatible providers (e.g. DO Inference) don't proxy — returns a 404 HTML page. Skip when `OPENAI_BASE_URL` is set to a non-default endpoint.

Production CI (Actions secret store) leaves `OPENAI_BASE_URL` and `VIJIL_LLM_MODEL` unset, so neither change affects main-branch runs.

## Test plan

- [ ] PR CI is green (main path, no env overrides).
- [ ] After merge + `@dependabot rebase`, the 6 stuck Dependabot PRs (#195, #197, #199, #222, #226, #231) go green and merge.