### PR TITLE
docs(trust): in-process control bypass threat model + tamper-evident identity-MAC plan

### DIFF
--- a/docs/trust/2026-06-04-in-process-control-bypass-threat-model.md
+++ b/docs/trust/2026-06-04-in-process-control-bypass-threat-model.md
@@ -79,9 +79,11 @@ The Prometheus metric governance would scrape (`<name>-error_total`) increments 
 an `except` around a *raised* scan (`guardrails/instrumentation/metrics.py:202-226`). The
 fail-open path returns a normal result **without raising**, so `error_total` never increments;
 `flagged_total` stays 0; `requests_total` and latency look healthy. The `secure_agent` audit
-stream (`runtime.py:312-319`) carries `flagged` + `score` only — on fail-open both are
-`False`/`0.0`, **byte-identical to a genuinely clean prompt**. The only governance-visible
-signal is a Tempo **trace attribute** `detection.label='errored'` (`telemetry.py:71-88`) — and
+stream (`runtime.py:312-319`) records `direction`, `flagged`, `score`, and `exec_time_ms`, but
+the discriminating detection fields (`flagged` + `score`) are `False`/`0.0` on fail-open,
+**byte-identical to a genuinely clean prompt** — only `exec_time_ms` may differ, and it is not a
+governance signal. The only governance-visible signal is a Tempo **trace attribute**
+`detection.label='errored'` (`vijil_dome/integrations/vijil/telemetry.py:71-88`) — and
 it exists only if `instrument_dome(tracer=…)` was wired, which the core `Dome()`/`TrustRuntime`
 constructors **do not do** (only the example/smoke tests do). Passive, query-only, opt-in. No
 in-repo rule alerts on it.
@@ -108,7 +110,8 @@ property:
    content-guard path. *(dome)*
 2. **Make the failure loud** — a `detector_unavailable_total` counter that increments *without*
    a raised exception, and carry `errored_methods` / `guards_disabled` into the audit event
-   (today `flagged`+`score` only). *(dome)*
+   (today `direction`/`flagged`/`score`/`exec_time_ms`, none of which flags an errored
+   detector). *(dome)*
 3. **An enforcement-alive heartbeat** signed with the agent's SVID, carrying effective mode +
    hooks-attached + detector-reachable. *(dome)*
 4. **A Console liveness reconciler + the missing-agent alert** — `last_dome_report_at` on the

--- a/docs/trust/2026-06-04-in-process-control-bypass-threat-model.md
+++ b/docs/trust/2026-06-04-in-process-control-bypass-threat-model.md
@@ -61,9 +61,10 @@ its own network egress.
 On `httpx.ConnectError` the dispatcher logs a warning, `break`s the retry loop, and returns
 `DetectorResult(is_flagged=False, score=0.0, error=…)` for **every** requested detector
 (`remote_dispatcher.py:222-258`). `RemoteDetectionMethod.detect()` launders that into
-`(False, …)` — *not a hit* (`remote_method.py:130-140`) — so the guard pipeline treats it as
+`(False, …)` — *not a hit* (`vijil_dome/detectors/methods/remote_method.py:130-140`) — so the guard pipeline treats it as
 *allow*. A **second** independent fail-open exists: the Guard layer wraps each detector in
-`asyncio.timeout(5.0)` and synthesizes `hit=False` on timeout (`guardrails/__init__.py:195-215`).
+`asyncio.timeout(DETECTOR_TIMEOUT_SECONDS)` (= 5 s) and synthesizes `hit=False` on timeout
+(`vijil_dome/guardrails/__init__.py:195-215`).
 
 The configurable fail-**closed** option exists — the native `ControlEngine` honors
 `action.on_error == 'fail_closed'` (`controls/engine.py:268-289`) — but **the legacy

--- a/docs/trust/2026-06-04-in-process-control-bypass-threat-model.md
+++ b/docs/trust/2026-06-04-in-process-control-bypass-threat-model.md
@@ -1,0 +1,142 @@
+# Threat model: bypassing in-process Dome controls
+
+- **Status:** Threat model (2026-06-04). Evidence-backed; every claim cites code.
+- **Scope:** the in-process Dome control stack (`secure_agent()` / `TrustRuntime` / the
+  guardrail + MAC pipeline) and whether an uncooperative agent developer can evade it.
+- **Method:** four independent adversarial code probes across `vijil-dome`, `vijil-console`,
+  `vijil-inference`, `vijil-darwin`.
+
+## The thesis under test
+
+> *"Vijil's in-process Dome controls can't be bypassed silently. An uncooperative developer
+> would have to **excommunicate their agent from the registry** to escape the controls — and
+> that absence **automatically triggers a governance alert** (a 'missing agent')."*
+
+This is the right **target**. It is **not true of the system today**, on either half: bypass
+does **not** require leaving the registry, and leaving the registry does **not** alarm.
+
+## Why it matters
+
+In-process enforcement is *cooperative* — it is a library call inside the agent's own process,
+not an external chokepoint. Its trust value therefore rests entirely on **tamper-evidence**:
+the property that you cannot remove or starve the control without producing a loud,
+governance-visible signal. If evasion is silent, "the agent is Dome-protected" is a claim the
+platform cannot stand behind. This document enumerates where that property fails and what
+restores it.
+
+## The control architecture (and its external dependency)
+
+`secure_agent(agent, agent_id=, mode=)` (`vijil_dome/trust/adapters/auto.py:31`) injects hooks
+into the agent object across three framework adapters (LangGraph / ADK / Strands). Four
+canonical in-process hook points: prompt-in (`guard_input`), response-out (`guard_output`),
+tool-call (`check_tool_call` = MAC), tool-response-out. Two enforcement classes:
+
+- **Content guards** (input/output detectors) — these call out to the **EKS-hosted detection
+  server** (`/v1/detect`) over HTTP. *In-process control with a remote dependency.*
+- **Tool MAC** (`ToolPolicy.check`) — local, no remote dependency.
+
+The remote dependency is the sharpest attack surface, because the agent's own process controls
+its own network egress.
+
+## The bypass surface (all verified, all keep the agent registered)
+
+| # | Bypass | Silent today | Leaves registry | Detectable today |
+|---|---|---|---|---|
+| 1 | **Block egress to `/v1/detect`** (DNS/firewall/NetworkPolicy) → content guards fail open | partial | no | partial (trace only, opt-in) |
+| 2 | **Slow-loris the detector** past the 5s/30s timeouts → same fail-open | partial | no | partial (latency only) |
+| 3 | **Run with no tracer wired** (core `Dome()`/`TrustRuntime` without `instrument_dome`) then trigger fail-open | **yes** | no | **no** |
+| 4 | **Default `mode='warn'`** — guards run, nothing blocks; or Dome init fails → `guards_disabled` | **yes** | no | partial |
+| 5 | **Never call `secure_agent()`** — registry row intact, no Dome code runs | **yes** | no | **no** |
+| 6 | **Monkey-patch the hooks** — `guard_input`/`guard_output` are mutable instance attributes | **yes** | no | **no** |
+| 7 | **Shape a LangGraph agent with no top-level `.tools`** → tool-MAC silently skipped | **yes** | no | **no** |
+
+### Hole 1 — the content guard fails OPEN by shipped default (the crux)
+
+`vijil_dome/detectors/remote_dispatcher.py:30-33` states it in the code's own words:
+
+> *"Graceful degradation: if the inference server is unreachable, all remote detectors return
+> `is_flagged=False` with an error field set… a server outage degrades coverage, not
+> availability."*
+
+On `httpx.ConnectError` the dispatcher logs a warning, `break`s the retry loop, and returns
+`DetectorResult(is_flagged=False, score=0.0, error=…)` for **every** requested detector
+(`remote_dispatcher.py:222-258`). `RemoteDetectionMethod.detect()` launders that into
+`(False, …)` — *not a hit* (`remote_method.py:130-140`) — so the guard pipeline treats it as
+*allow*. A **second** independent fail-open exists: the Guard layer wraps each detector in
+`asyncio.timeout(5.0)` and synthesizes `hit=False` on timeout (`guardrails/__init__.py:195-215`).
+
+The configurable fail-**closed** option exists — the native `ControlEngine` honors
+`action.on_error == 'fail_closed'` (`controls/engine.py:268-289`) — but **the legacy
+TOML/dict guardrail path that `secure_agent` actually runs has no `on_error` knob**; it
+hardcodes `hit=False` on every error/timeout. So fail-closed is not reachable from the
+shipped content-guard pipeline. `route=remote` does **not** help: it raises only at
+config-parse time if the URL is unset (`config_parser.py:147-160`); a firewall applied after
+startup is a pure runtime `ConnectError` → fail-open.
+
+### Hole 2 — the fail-open is nearly invisible
+
+The Prometheus metric governance would scrape (`<name>-error_total`) increments **only** inside
+an `except` around a *raised* scan (`guardrails/instrumentation/metrics.py:202-226`). The
+fail-open path returns a normal result **without raising**, so `error_total` never increments;
+`flagged_total` stays 0; `requests_total` and latency look healthy. The `secure_agent` audit
+stream (`runtime.py:312-319`) carries `flagged` + `score` only — on fail-open both are
+`False`/`0.0`, **byte-identical to a genuinely clean prompt**. The only governance-visible
+signal is a Tempo **trace attribute** `detection.label='errored'` (`telemetry.py:71-88`) — and
+it exists only if `instrument_dome(tracer=…)` was wired, which the core `Dome()`/`TrustRuntime`
+constructors **do not do** (only the example/smoke tests do). Passive, query-only, opt-in. No
+in-repo rule alerts on it.
+
+### Hole 3 — there is no "missing agent" alert
+
+No liveness / heartbeat / last-seen / dark-agent / posture-downgrade detector exists anywhere
+in Console. The Trust dashboard reads a **static** `dome_protected` flag plus a hard-coded
+empty "under attack" stub (`dome_adapter.py:38`). `attestation_status` (the CON-522 field) is
+**written and watched by nothing**; `attested_at` is never re-evaluated; `INCONCLUSIVE` is
+never set. **Registration is orthogonal to execution** — `create_agent` is a catalog write with
+no runtime hook (`service.py:71-132`); an agent can run unwrapped and never register. Even
+archiving (the only de-registration path) emits no event. So even if an attacker *did*
+excommunicate, nothing alarms.
+
+## What makes the thesis true (the convergent build)
+
+Four probes reading four subsystems independently converged on the same bounded set — the
+"tamper-evidence" spine that turns *bypass ⇒ excommunication ⇒ alarm* from aspiration into a
+property:
+
+1. **Fail-CLOSED on detector-unreachable** in enforce mode — block (or loudly degrade) instead
+   of silently passing; bring the `ControlEngine`'s `on_error` semantics to the default
+   content-guard path. *(dome)*
+2. **Make the failure loud** — a `detector_unavailable_total` counter that increments *without*
+   a raised exception, and carry `errored_methods` / `guards_disabled` into the audit event
+   (today `flagged`+`score` only). *(dome)*
+3. **An enforcement-alive heartbeat** signed with the agent's SVID, carrying effective mode +
+   hooks-attached + detector-reachable. *(dome)*
+4. **A Console liveness reconciler + the missing-agent alert** — `last_dome_report_at` on the
+   agent record, a staleness sweep that flips `ATTESTED→INCONCLUSIVE` and flags `dome_protected`
+   agents that go dark / drop to warn / lose attestation; wire `attestation_status` into the
+   dashboard; **rogue-agent reconciliation** (traffic with no registry row). *(console — this is
+   literally the "missing agent" alarm.)*
+5. **Reject local `warn` overriding a Console-mandated `enforce`** — record the downgrade as a
+   governance event (`runtime.py:92-94`). *(dome)*
+
+## The durable root of trust (roadmap, founder direction)
+
+Items 1–5 raise the cost of evasion and make it **loud** — the correct bar for the
+**cooperative-developer** threat model. They do **not** stop a **malicious in-process** attacker
+(arbitrary code can patch a library call). The durable answer is to move the root of trust into
+**hardware**: a **TPM-rooted measured boot** with the agent container running inside a **TEE**
+(confidential compute; see the Phala × Vijil direction), so the Dome control stack is
+*measured and sealed* and its integrity is attested by hardware rather than asserted by a
+cooperating process. The in-process heartbeat (item 3) becomes a TEE **remote-attestation
+quote** rather than an SVID-signed beacon. This is the strategic end state; items 1–5 are the
+software increment that delivers tamper-*evidence* now and composes cleanly with it.
+
+## Threat-model boundary (honest)
+
+- **In scope / addressed by 1–5:** an uncooperative developer who starves, downgrades, or
+  declines the control — every such move becomes governance-visible.
+- **Out of scope for the software increment:** a malicious process with code execution that
+  patches Dome in-memory — only the TEE/TPM root of trust closes this.
+- **The non-bypassable backstop remains the network proxy**, where Vijil owns the chokepoint:
+  in-process control is for *portability + tamper-evidence*; the proxy is for *un-bypassable
+  enforcement* where the network is controlled. The two are complementary, not redundant.

--- a/docs/trust/2026-06-04-tamper-evident-identity-mac-plan.md
+++ b/docs/trust/2026-06-04-tamper-evident-identity-mac-plan.md
@@ -30,12 +30,12 @@ needs a review; `vijil-proxy-servers`/`vijil-sdk` unprotected. **The bulk of thi
 
 | ID | Unit | Repo | Size | Depends |
 |---|---|---|---|---|
-| **A1** | **Keystone:** thread `spiffe_id`+attested into `ToolPolicy.check` / `check_tool_call` / `wrap_tool`; set `ToolCallResult.identity_verified` from real state (it is hardcoded `False` today) | dome | M | — |
+| ~~**A1**~~ | ~~**Keystone:** thread `spiffe_id`+attested into `ToolPolicy.check` / `check_tool_call` / `wrap_tool`; set `ToolCallResult.identity_verified` from real state~~ **✅ LANDED** (#242, `0e1a301`): `identity_verified` is set from real state; `agent_spiffe_id` is emitted in the audit stream. | dome | — | — |
 | A2 | Fail-closed-on-unattested in enforce mode (today an unattested process still gets policy) | dome | S | A1 |
 | A3 | Bind policy to the SVID: assert the policy subject matches `self._identity.spiffe_id`; fail-closed on mismatch (closes the "load any agent's constraints with an API token" priv-esc) | dome | S | A1 |
 | A4 | Model-MAC: `allowed_models` / `max_tokens` / `allow_tool_use` + a `before_model` authorization hook, mirroring the proxy `checkMAC` field model | dome | M | A1 |
 | A5 | SVID-glob policy resolution (first-match), mirroring the proxy `MatchRoute` | dome | M | A1 |
-| A6 | Emit the agent SPIFFE ID in the audit stream (the reported-but-absent `agent_identity`) | dome | S | A1 |
+| ~~A6~~ | ~~Emit the agent SPIFFE ID in the audit stream (the reported-but-absent `agent_identity`)~~ **✅ FOLDED INTO A1** (#242): audit field is `agent_spiffe_id`, not `agent_identity`. | dome | — | — |
 | A7 | Declare the `spiffe` package (the py-spiffe project; imported and installed as `spiffe`) as an `identity` extra + lockfile (X.509 attestation is dead in a locked install today) | dome | S | — |
 | A8 | Console: materialize real per-identity MAC rulesets (replace the empty stubs at `constraints/service.py:117-123`); operator-authored domain | console | L | — |
 | A9 | Console: `get_by_spiffe_id` resolver + a workload-auth `/constraints` endpoint (present an SVID, not a human JWT) | console | M | A8 |

--- a/docs/trust/2026-06-04-tamper-evident-identity-mac-plan.md
+++ b/docs/trust/2026-06-04-tamper-evident-identity-mac-plan.md
@@ -36,7 +36,7 @@ needs a review; `vijil-proxy-servers`/`vijil-sdk` unprotected. **The bulk of thi
 | A4 | Model-MAC: `allowed_models` / `max_tokens` / `allow_tool_use` + a `before_model` authorization hook, mirroring the proxy `checkMAC` field model | dome | M | A1 |
 | A5 | SVID-glob policy resolution (first-match), mirroring the proxy `MatchRoute` | dome | M | A1 |
 | A6 | Emit the agent SPIFFE ID in the audit stream (the reported-but-absent `agent_identity`) | dome | S | A1 |
-| A7 | Declare `py-spiffe` as an `identity` extra + lockfile (X.509 attestation is dead in a locked install today) | dome | S | — |
+| A7 | Declare the `spiffe` package (the py-spiffe project; imported and installed as `spiffe`) as an `identity` extra + lockfile (X.509 attestation is dead in a locked install today) | dome | S | — |
 | A8 | Console: materialize real per-identity MAC rulesets (replace the empty stubs at `constraints/service.py:117-123`); operator-authored domain | console | L | — |
 | A9 | Console: `get_by_spiffe_id` resolver + a workload-auth `/constraints` endpoint (present an SVID, not a human JWT) | console | M | A8 |
 | A10 | Dome: fetch constraints **by SVID** instead of the developer-supplied `agent_id` string | dome | M | A1, A9 |

--- a/docs/trust/2026-06-04-tamper-evident-identity-mac-plan.md
+++ b/docs/trust/2026-06-04-tamper-evident-identity-mac-plan.md
@@ -1,0 +1,86 @@
+# Plan: tamper-evident in-process identity-MAC
+
+- **Status:** Plan (2026-06-04). Companion to `2026-06-04-in-process-control-bypass-threat-model.md`.
+- **Goal:** make Vijil's in-process Dome controls enforce **mandatory access control keyed on
+  the agent's attested SPIFFE identity**, AND make evasion of that control **loud** — so the
+  only way out is to go dark, and going dark alarms.
+- **Why now:** this is the differentiated "trustworthy AI" primitive, it is almost entirely
+  **offline-buildable**, and it sidesteps every cluster-gated blocker the out-of-process proxy
+  MAC carries (the X.509↔JWT seam, admin-socket exposure, single-cluster convergence).
+
+## Resource model
+
+The only two actors are the agent (me, fanning out sub-agents) and the founder. The only
+external blockers are **(a) human PR approval on protected repos** and **(b) decisions only the
+founder makes**. Repo gating (verified `gh api`): `vijil-dome` is protected **but
+`enforce_admins=false`** → founder-admin-mergeable without waiting on CODEOWNERS; `vijil-console`
+needs a review; `vijil-proxy-servers`/`vijil-sdk` unprotected. **The bulk of this work is in
+`vijil-dome` — the repo the founder can self-unblock.**
+
+## Decided forks (founder, 2026-06-04)
+
+1. **MAC policy key = the attested SPIFFE ID** (`spiffe://vijil.ai/org/<team>/agent/<uuid>`),
+   not the Console agent UUID.
+2. **Policy source = operator-authored** MAC rulesets for now; the ODRL-policy→MAC compiler is
+   a fast-follow (it is lossy and shouldn't gate the demo).
+
+## The build — two halves, one spine
+
+### Half A — Identity-MAC (the decision is keyed on who the agent is)
+
+| ID | Unit | Repo | Size | Depends |
+|---|---|---|---|---|
+| **A1** | **Keystone:** thread `spiffe_id`+attested into `ToolPolicy.check` / `check_tool_call` / `wrap_tool`; set `ToolCallResult.identity_verified` from real state (it is hardcoded `False` today) | dome | M | — |
+| A2 | Fail-closed-on-unattested in enforce mode (today an unattested process still gets policy) | dome | S | A1 |
+| A3 | Bind policy to the SVID: assert the policy subject matches `self._identity.spiffe_id`; fail-closed on mismatch (closes the "load any agent's constraints with an API token" priv-esc) | dome | S | A1 |
+| A4 | Model-MAC: `allowed_models` / `max_tokens` / `allow_tool_use` + a `before_model` authorization hook, mirroring the proxy `checkMAC` field model | dome | M | A1 |
+| A5 | SVID-glob policy resolution (first-match), mirroring the proxy `MatchRoute` | dome | M | A1 |
+| A6 | Emit the agent SPIFFE ID in the audit stream (the reported-but-absent `agent_identity`) | dome | S | A1 |
+| A7 | Declare `py-spiffe` as an `identity` extra + lockfile (X.509 attestation is dead in a locked install today) | dome | S | — |
+| A8 | Console: materialize real per-identity MAC rulesets (replace the empty stubs at `constraints/service.py:117-123`); operator-authored domain | console | L | — |
+| A9 | Console: `get_by_spiffe_id` resolver + a workload-auth `/constraints` endpoint (present an SVID, not a human JWT) | console | M | A8 |
+| A10 | Dome: fetch constraints **by SVID** instead of the developer-supplied `agent_id` string | dome | M | A1, A9 |
+| A11 | Identity-keyed e2e: same tool/model, two SVIDs → permit vs deny; mismatch → deny; unattested → deny | dome | M | A1, A3 |
+
+### Half B — Tamper-evidence (you can't silently remove or starve the control)
+
+| ID | Unit | Repo | Size | Depends |
+|---|---|---|---|---|
+| **B1** | **Fail-CLOSED on detector-unreachable** in enforce mode — bring the `ControlEngine.on_error` semantics to the legacy content-guard path (`secure_agent` runs the legacy path, which hardcodes `hit=False`) | dome | M | — |
+| B2 | Loud-fail: `detector_unavailable_total` metric that fires **without** a raised exception, + carry `errored_methods`/`guards_disabled` into the audit event | dome | S | B1 |
+| B3 | Enforcement-alive heartbeat: a periodic beacon (SVID-signed now; TEE-quote later) carrying effective mode + hooks-attached + detector-reachable | dome | M | A6 |
+| B4 | Console liveness reconciler + **missing-agent alert**: `last_dome_report_at`, staleness sweep, `ATTESTED→INCONCLUSIVE`, dashboard wiring, rogue-agent reconciliation (traffic with no registry row) | console | L | B3 |
+| B5 | Reject local `warn` overriding a Console-mandated `enforce`; record the downgrade as a governance event | dome | S | A1 |
+| B6 | Single-source-of-truth policy-schema doc (proxy field model ↔ in-process) | dome | S | — |
+
+## Execution waves
+
+- **Wave 1** (parallel, no cross-deps): **A1 keystone** ‖ A7 ‖ B1 ‖ B6 ‖ A8 (Console greenfield).
+  A1 is a signature change on the MAC hot path consumed by 3 adapters — front-load the
+  consumer-graph grep, land it as one consolidated PR, review hard.
+- **Wave 2** (after A1): A2 ‖ A3 ‖ A4 ‖ A5 ‖ A6 ‖ B2 ‖ B5 — fan out.
+- **Wave 3**: A9 ‖ B3 → A10 ‖ B4 ‖ A11 (the e2e proof).
+
+Each unit = a TDD'd PR through the `vijil-code` loop + adversarial review + Copilot-wave
+convergence. I drive the build; the founder clears merges.
+
+## Friday demo cut (offline, dome-only ⇒ founder-admin-mergeable)
+
+A1 + A2 + A3 + A4 + B1 + B2 + A7 + A11 + an operator-authored demo policy. Two beats:
+
+1. **Deny-by-identity:** the same tool/model call, two different attested identities → permit
+   vs deny, in-process, no proxy, no cluster.
+2. **Tamper-evidence:** starve the detector (block `/v1/detect`) → the call is **BLOCKED** and a
+   **loud** governance signal fires — not the silent fail-open it is today.
+
+Beat 2 is the differentiator: a control you cannot quietly delete or starve.
+
+## Needs the founder
+
+- **Forks:** decided (above). ✓
+- **Approvals:** dome admin-merges (you) + console PR reviews.
+- **One demo decision:** confirm we demo **both** beats (recommend yes — beat 2 is the
+  differentiator).
+- **Roadmap (no action this sprint):** TPM-rooted measured boot + TEE-hosted agent (Phala ×
+  Vijil) as the hardware root of trust — turns items B1–B5 from tamper-*evidence* into
+  tamper-*proof*, and the B3 heartbeat into a remote-attestation quote.


### PR DESCRIPTION
## What

Two reference docs under `docs/trust/`:

1. **`2026-06-04-in-process-control-bypass-threat-model.md`** — an evidence-backed threat model (four adversarial code probes) testing the thesis *"bypassing in-process Dome controls requires excommunicating the agent from the registry, which alarms as a 'missing agent.'"* **Verdict: false today, on both halves** — five silent, registry-intact bypasses, the content guard fails OPEN on detector-unreachable, and no missing-agent alert exists. Every claim cites `file:line`.

2. **`2026-06-04-tamper-evident-identity-mac-plan.md`** — the build that makes the thesis true: one *tamper-evident identity-MAC* feature (Half A keys the MAC decision on the attested SPIFFE identity; Half B makes evasion loud). Forks decided (SPIFFE-ID key; operator-authored policy). TEE/TPM measured boot noted as the durable root of trust.

## Why
In-process enforcement is cooperative — its trust value rests entirely on tamper-evidence. These docs establish the evidence trail and the plan before the implementation PRs land.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)