### PR TITLE
feat(dome): thread attested SPIFFE identity into the MAC decision + audit [DOME-164]

### DIFF
--- a/vijil_dome/tests/trust/test_identity_mac_a1.py
+++ b/vijil_dome/tests/trust/test_identity_mac_a1.py
@@ -1,0 +1,151 @@
+"""A1 (DOME-164): the MAC decision is threaded with the agent's attested identity.
+
+Observe-only: ``identity_verified`` + ``agent_spiffe_id`` reflect real attestation state, but
+permit/deny behavior is unchanged (enforcement lands later in A2/A3 behind a mode).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from vijil_dome.trust.constraints import AgentConstraints
+from vijil_dome.trust.policy import ToolPolicy
+from vijil_dome.trust.runtime import TrustRuntime
+
+_SPIFFE = "spiffe://vijil.ai/org/team-1/agent/agent-1"
+
+
+def _constraints(*, enforcement_mode: str = "enforce") -> AgentConstraints:
+    return AgentConstraints.model_validate(
+        {
+            "agent_id": "agent-1",
+            "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+            "tool_permissions": [
+                {"name": "book_flight", "identity": "spiffe://vijil.ai/tools/book_flight/v1",
+                 "endpoint": "mcp+tls://book_flight.internal:8443"},
+            ],
+            "organization": {
+                "required_input_guards": [], "required_output_guards": [],
+                "denied_tools": ["charge_card"],
+            },
+            "enforcement_mode": enforcement_mode,
+            "updated_at": "2026-04-03T12:00:00+00:00",
+        }
+    )
+
+
+def _runtime() -> TrustRuntime:
+    client = MagicMock()
+    client._http._token = "test-api-key"  # api-key path -> unattested
+    client._http.get.return_value = _constraints().model_dump(mode="json")
+    return TrustRuntime(client=client, agent_id="agent-1", mode="enforce")
+
+
+# --- ToolPolicy.check threads identity ---------------------------------------
+
+
+def test_check_records_attested_identity_on_permit() -> None:
+    result = ToolPolicy(_constraints()).check("book_flight", {}, spiffe_id=_SPIFFE, attested=True)
+    assert result.permitted is True
+    assert result.identity_verified is True
+    assert result.agent_spiffe_id == _SPIFFE
+
+
+def test_check_records_identity_on_deny_too() -> None:
+    result = ToolPolicy(_constraints()).check("charge_card", {}, spiffe_id=_SPIFFE, attested=True)
+    assert result.permitted is False  # denied tool
+    assert result.identity_verified is True  # identity still recorded on a deny
+    assert result.agent_spiffe_id == _SPIFFE
+
+
+def test_check_unattested_is_not_verified() -> None:
+    result = ToolPolicy(_constraints()).check("book_flight", {}, spiffe_id=None, attested=False)
+    assert result.identity_verified is False
+    assert result.agent_spiffe_id is None
+
+
+def test_identity_does_not_change_permit_deny() -> None:
+    # Observe-only: attestation must not alter the permit/deny outcome in A1.
+    policy = ToolPolicy(_constraints())
+    assert policy.check("book_flight", {}, attested=False).permitted is True
+    assert policy.check("book_flight", {}, attested=True).permitted is True
+    assert policy.check("charge_card", {}, attested=True).permitted is False
+
+
+# --- TrustRuntime.check_tool_call threads its own identity -------------------
+
+
+def test_check_tool_call_reflects_attested_runtime_identity() -> None:
+    runtime = _runtime()
+    runtime._identity = MagicMock()
+    runtime._identity.is_attested.return_value = True
+    runtime._identity.spiffe_id = _SPIFFE
+    result = runtime.check_tool_call("book_flight", {})
+    assert result.identity_verified is True
+    assert result.agent_spiffe_id == _SPIFFE
+
+
+def test_check_tool_call_unattested_runtime_identity_not_verified() -> None:
+    result = _runtime().check_tool_call("book_flight", {})  # api-key -> unattested
+    assert result.identity_verified is False
+
+
+# --- the audit event carries the attested identity (A6 folded into A1) -------
+
+
+def _attested_runtime_with_audit_capture() -> tuple[TrustRuntime, list]:
+    runtime = _runtime()
+    runtime._identity = MagicMock()
+    runtime._identity.is_attested.return_value = True
+    runtime._identity.spiffe_id = _SPIFFE
+    events: list = []
+    runtime._audit._sink = events.append
+    return runtime, events
+
+
+def test_audit_event_carries_spiffe_id_on_permit() -> None:
+    runtime, events = _attested_runtime_with_audit_capture()
+    runtime.check_tool_call("book_flight", {})  # permitted tool
+    assert events[-1].event_type == "tool_mac"
+    assert events[-1].attributes["agent_spiffe_id"] == _SPIFFE
+    assert events[-1].attributes["identity_verified"] is True
+    assert events[-1].attributes["permitted"] is True
+
+
+def test_audit_event_carries_spiffe_id_on_deny() -> None:
+    runtime, events = _attested_runtime_with_audit_capture()
+    runtime.check_tool_call("charge_card", {})  # denied tool
+    assert events[-1].attributes["agent_spiffe_id"] == _SPIFFE
+    assert events[-1].attributes["permitted"] is False
+
+
+# --- identity is threaded on every deny path, incl. allowed_actions ----------
+
+
+def test_check_allowed_actions_deny_threads_identity() -> None:
+    constraints = AgentConstraints.model_validate(
+        {
+            "agent_id": "agent-1",
+            "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+            "tool_permissions": [
+                {"name": "book_flight", "identity": "spiffe://vijil.ai/tools/book_flight/v1",
+                 "endpoint": "mcp+tls://book_flight.internal:8443", "allowed_actions": ["read"]},
+            ],
+            "organization": {"required_input_guards": [], "required_output_guards": [], "denied_tools": []},
+            "enforcement_mode": "enforce",
+            "updated_at": "2026-04-03T12:00:00+00:00",
+        }
+    )
+    result = ToolPolicy(constraints).check(
+        "book_flight", {"action": "write"}, spiffe_id=_SPIFFE, attested=True
+    )
+    assert result.permitted is False  # action not in allowed_actions
+    assert result.identity_verified is True
+    assert result.agent_spiffe_id == _SPIFFE
+
+
+def test_check_defaults_to_unattested_when_identity_kwargs_omitted() -> None:
+    # Omitting the identity kwargs defaults to unattested / no spiffe_id.
+    result = ToolPolicy(_constraints()).check("book_flight", {})
+    assert result.identity_verified is False
+    assert result.agent_spiffe_id is None

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -67,13 +67,20 @@ class AuditEmitter:
         *,
         permitted: bool,
         identity_verified: bool,
+        agent_spiffe_id: str | None = None,
     ) -> None:
-        """Emit a tool MAC enforcement event."""
+        """Emit a tool MAC enforcement event.
+
+        ``agent_spiffe_id`` records the attested principal the MAC decision was
+        made for, so the binding between the decision and the caller is auditable
+        downstream. It is meaningful only when ``identity_verified`` is True.
+        """
         self._emit(
             "tool_mac",
             tool_name=tool_name,
             permitted=permitted,
             identity_verified=identity_verified,
+            agent_spiffe_id=agent_spiffe_id,
         )
 
     def emit_attestation(

--- a/vijil_dome/trust/policy.py
+++ b/vijil_dome/trust/policy.py
@@ -15,6 +15,7 @@ class ToolCallResult(BaseModel):
     tool_name: str
     args: dict[str, Any] | None = None
     identity_verified: bool = False
+    agent_spiffe_id: str | None = None
     policy_permitted: bool = False
     enforced: bool = False
     error: str | None = None
@@ -48,6 +49,9 @@ class ToolPolicy:
         self,
         tool_name: str,
         args: dict[str, Any] | None = None,
+        *,
+        spiffe_id: str | None = None,
+        attested: bool = False,
     ) -> ToolCallResult:
         """Return a ToolCallResult reflecting the MAC decision.
 
@@ -56,13 +60,26 @@ class ToolPolicy:
             args: The arguments passed to the tool. Currently logged for
                 audit; future versions may enforce parameter-level constraints
                 (e.g., allowed parameter ranges, required fields).
+            spiffe_id: The calling agent's SPIFFE ID, recorded on the result for
+                audit. Threaded for downstream identity-keyed policy (A2/A3); the
+                permit/deny outcome is NOT keyed on it here. It is recorded even
+                when ``attested`` is False, so consumers MUST gate on
+                ``identity_verified`` before keying any decision on it.
+            attested: Whether the agent's identity is attested. Recorded as
+                ``identity_verified``; does not change the outcome in this step.
         """
         if tool_name in self._denied_tools:
-            return self._deny(tool_name, "denied by organization constraints", args)
+            return self._deny(
+                tool_name, "denied by organization constraints", args,
+                spiffe_id=spiffe_id, attested=attested,
+            )
 
         perm = self._permissions.get(tool_name)
         if perm is None:
-            return self._deny(tool_name, "not in agent permissions", args)
+            return self._deny(
+                tool_name, "not in agent permissions", args,
+                spiffe_id=spiffe_id, attested=attested,
+            )
 
         # Check allowed_actions if the permission restricts them.
         # Fail-closed: missing or None action is denied when allowed_actions is set.
@@ -73,12 +90,16 @@ class ToolPolicy:
                     tool_name,
                     f"action {action!r} not in allowed_actions {perm.allowed_actions}",
                     args,
+                    spiffe_id=spiffe_id,
+                    attested=attested,
                 )
 
         return ToolCallResult(
             permitted=True,
             tool_name=tool_name,
             args=args,
+            identity_verified=attested,
+            agent_spiffe_id=spiffe_id,
             policy_permitted=True,
         )
 
@@ -91,13 +112,21 @@ class ToolPolicy:
     # ------------------------------------------------------------------
 
     def _deny(
-        self, tool_name: str, error: str, args: dict[str, Any] | None = None
+        self,
+        tool_name: str,
+        error: str,
+        args: dict[str, Any] | None = None,
+        *,
+        spiffe_id: str | None = None,
+        attested: bool = False,
     ) -> ToolCallResult:
         enforced = self._enforcement_mode == "enforce"
         return ToolCallResult(
             permitted=False,
             tool_name=tool_name,
             args=args,
+            identity_verified=attested,
+            agent_spiffe_id=spiffe_id,
             policy_permitted=False,
             enforced=enforced,
             error=error,

--- a/vijil_dome/trust/policy.py
+++ b/vijil_dome/trust/policy.py
@@ -57,9 +57,10 @@ class ToolPolicy:
 
         Args:
             tool_name: The tool being called.
-            args: The arguments passed to the tool. Currently logged for
-                audit; future versions may enforce parameter-level constraints
-                (e.g., allowed parameter ranges, required fields).
+            args: The arguments passed to the tool. Carried on the result for
+                potential downstream audit/debugging (not emitted today); future
+                versions may enforce parameter-level constraints (e.g., allowed
+                parameter ranges, required fields).
             spiffe_id: The calling agent's SPIFFE ID, recorded on the result for
                 audit. Threaded for downstream identity-keyed policy (A2/A3); the
                 permit/deny outcome is NOT keyed on it here. It is recorded even

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -351,11 +351,17 @@ class TrustRuntime:
 
     def check_tool_call(self, tool_name: str, args: dict[str, Any]) -> ToolCallResult:
         """Check whether a tool call is permitted by policy."""
-        result = self._policy.check(tool_name, args=args)
+        result = self._policy.check(
+            tool_name,
+            args=args,
+            spiffe_id=self._identity.spiffe_id,
+            attested=self._identity.is_attested(),
+        )
         self._audit.emit_tool_mac(
             tool_name,
             permitted=result.permitted,
             identity_verified=result.identity_verified,
+            agent_spiffe_id=result.agent_spiffe_id,
         )
         return result
 


### PR DESCRIPTION
## What
The **keystone** of tamper-evident identity-MAC (DOME-163, plan in PR #239). **Observe-only**: the MAC result + audit now reflect *real* attestation state, with **no change to any permit/deny outcome** (enforcement lands in A2/A3 behind a mode).

- `policy.py`: `ToolCallResult.agent_spiffe_id`; `ToolPolicy.check`/`_deny` take keyword-only `spiffe_id`+`attested` (defaulted → existing callers unchanged) and set `identity_verified` from `attested` (was hardcoded `False`) + record the SPIFFE ID on **every** permit and deny path.
- `runtime.py`: `check_tool_call` threads `self._identity.spiffe_id` + `is_attested()` into the policy and the audit.
- `audit.py`: `emit_tool_mac` carries `agent_spiffe_id` so the decision↔principal binding is auditable (folds in A6).

## Why it's safe
Blast radius verified: `ToolPolicy.check` has **one** caller; the 3 framework adapters thread identity internally, so they're untouched (adapter tool-MAC e2e stays green). Keyword-only defaulted params preserve every existing caller.

## Verification
10 new tests (attested→verified / unattested→not; identity recorded on every deny path incl. `allowed_actions`; audit carries the SPIFFE ID on permit+deny; defaults unattested when kwargs omitted; **permit/deny unchanged by identity**). **132 trust-core + adapter-MAC tests pass; ruff + mypy clean.** 2-lens adversarial review (fit PASS; security REVISE→addressed).

**Disclosed follow-up:** pre-existing dead code at `runtime.py:232-238` (unreachable emit after `return` in `apply_evaluation`) — filed separately, out of A1 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)