### PR TITLE
feat(dome): enforcement-alive heartbeat event shape + emit [DOME-163]

### DIFF
--- a/vijil_dome/tests/trust/test_heartbeat_b3.py
+++ b/vijil_dome/tests/trust/test_heartbeat_b3.py
@@ -168,6 +168,19 @@ def test_runtime_emit_heartbeat_detector_unreachable_when_guards_disabled() -> N
     assert events[-1].attributes["detector_reachable"] is False
 
 
+def test_runtime_emit_heartbeat_no_guards_means_detector_not_reachable() -> None:
+    # varunc1996 review of #245: with no guards configured (_dome is None) and guards NOT
+    # disabled, detector_reachable must be False — "no detector configured" must not read as
+    # "detector reachable" (the B4 reconciler keys on it). A real reachability probe is DOME-169.
+    events: list[AuditEvent] = []
+    runtime = _runtime()  # empty guards -> _dome is None, _guards_disabled stays False
+    runtime._audit._sink = events.append
+
+    runtime.emit_heartbeat()
+
+    assert events[-1].attributes["detector_reachable"] is False
+
+
 def test_runtime_emit_heartbeat_returns_heartbeat_model() -> None:
     runtime = _runtime()
     hb = runtime.emit_heartbeat()

--- a/vijil_dome/tests/trust/test_heartbeat_b3.py
+++ b/vijil_dome/tests/trust/test_heartbeat_b3.py
@@ -26,25 +26,29 @@ _SPIFFE = "spiffe://vijil.ai/org/team-1/agent/agent-1"
 
 def test_heartbeat_model_fields() -> None:
     hb = Heartbeat(
-        effective_mode="enforce",
-        hooks_attached=True,
+        configured_mode="enforce",
+        guards_constructed=True,
         detector_reachable=True,
+        attested=True,
         agent_spiffe_id=_SPIFFE,
     )
-    assert hb.effective_mode == "enforce"
-    assert hb.hooks_attached is True
+    assert hb.configured_mode == "enforce"
+    assert hb.guards_constructed is True
     assert hb.detector_reachable is True
+    assert hb.attested is True
     assert hb.agent_spiffe_id == _SPIFFE
 
 
-def test_heartbeat_spiffe_id_optional() -> None:
-    # An unattested agent still emits a beacon — the spiffe_id is just absent.
+def test_heartbeat_unattested_spiffe_is_none() -> None:
+    # An unattested agent emits a beacon with attested=False and agent_spiffe_id=None.
     hb = Heartbeat(
-        effective_mode="warn",
-        hooks_attached=False,
+        configured_mode="warn",
+        guards_constructed=False,
         detector_reachable=False,
+        attested=False,
         agent_spiffe_id=None,
     )
+    assert hb.attested is False
     assert hb.agent_spiffe_id is None
 
 
@@ -58,9 +62,10 @@ def test_emit_heartbeat_event_shape() -> None:
     emitter = AuditEmitter(agent_id="agent-hb", sink=events.append)
 
     emitter.emit_heartbeat(
-        effective_mode="enforce",
-        hooks_attached=True,
+        configured_mode="enforce",
+        guards_constructed=True,
         detector_reachable=True,
+        attested=True,
         agent_spiffe_id=_SPIFFE,
     )
 
@@ -68,9 +73,10 @@ def test_emit_heartbeat_event_shape() -> None:
     event = events[0]
     assert event.event_type == "enforcement_heartbeat"
     assert event.agent_id == "agent-hb"
-    assert event.attributes["effective_mode"] == "enforce"
-    assert event.attributes["hooks_attached"] is True
+    assert event.attributes["configured_mode"] == "enforce"
+    assert event.attributes["guards_constructed"] is True
     assert event.attributes["detector_reachable"] is True
+    assert event.attributes["attested"] is True
     assert event.attributes["agent_spiffe_id"] == _SPIFFE
 
 
@@ -79,15 +85,17 @@ def test_emit_heartbeat_unattested_carries_none_spiffe() -> None:
     emitter = AuditEmitter(agent_id="agent-hb", sink=events.append)
 
     emitter.emit_heartbeat(
-        effective_mode="warn",
-        hooks_attached=False,
+        configured_mode="warn",
+        guards_constructed=False,
         detector_reachable=False,
+        attested=False,
         agent_spiffe_id=None,
     )
 
     assert events[-1].event_type == "enforcement_heartbeat"
     assert events[-1].attributes["agent_spiffe_id"] is None
-    assert events[-1].attributes["hooks_attached"] is False
+    assert events[-1].attributes["attested"] is False
+    assert events[-1].attributes["guards_constructed"] is False
     assert events[-1].attributes["detector_reachable"] is False
 
 
@@ -128,7 +136,7 @@ def test_runtime_emit_heartbeat_reports_effective_mode() -> None:
     runtime.emit_heartbeat()
 
     assert events[-1].event_type == "enforcement_heartbeat"
-    assert events[-1].attributes["effective_mode"] == "enforce"
+    assert events[-1].attributes["configured_mode"] == "enforce"
 
 
 def test_runtime_emit_heartbeat_reports_attested_spiffe_id() -> None:
@@ -152,7 +160,7 @@ def test_runtime_emit_heartbeat_no_guards_means_hooks_not_attached() -> None:
 
     runtime.emit_heartbeat()
 
-    assert events[-1].attributes["hooks_attached"] is False
+    assert events[-1].attributes["guards_constructed"] is False
 
 
 def test_runtime_emit_heartbeat_detector_unreachable_when_guards_disabled() -> None:
@@ -185,4 +193,4 @@ def test_runtime_emit_heartbeat_returns_heartbeat_model() -> None:
     runtime = _runtime()
     hb = runtime.emit_heartbeat()
     assert isinstance(hb, Heartbeat)
-    assert hb.effective_mode == "enforce"
+    assert hb.configured_mode == "enforce"

--- a/vijil_dome/tests/trust/test_heartbeat_b3.py
+++ b/vijil_dome/tests/trust/test_heartbeat_b3.py
@@ -1,0 +1,175 @@
+"""B3 (DOME-163): enforcement-alive heartbeat.
+
+A wrapped agent emits a signed-later 'I am enforcing' beacon so a registered
+agent that goes dark or silently downgrades is detectable downstream.
+
+Scope of B3: the event shape (``Heartbeat`` model) + emit
+(``AuditEmitter.emit_heartbeat`` and ``TrustRuntime.emit_heartbeat``).
+Periodic scheduling and SVID-signing are a follow-up.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from vijil_dome.trust.audit import AuditEmitter, AuditEvent, Heartbeat
+from vijil_dome.trust.constraints import AgentConstraints
+from vijil_dome.trust.runtime import TrustRuntime
+
+_SPIFFE = "spiffe://vijil.ai/org/team-1/agent/agent-1"
+
+
+# ---------------------------------------------------------------------------
+# 1. Heartbeat pydantic model carries the four enforcement-liveness fields
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_model_fields() -> None:
+    hb = Heartbeat(
+        effective_mode="enforce",
+        hooks_attached=True,
+        detector_reachable=True,
+        agent_spiffe_id=_SPIFFE,
+    )
+    assert hb.effective_mode == "enforce"
+    assert hb.hooks_attached is True
+    assert hb.detector_reachable is True
+    assert hb.agent_spiffe_id == _SPIFFE
+
+
+def test_heartbeat_spiffe_id_optional() -> None:
+    # An unattested agent still emits a beacon — the spiffe_id is just absent.
+    hb = Heartbeat(
+        effective_mode="warn",
+        hooks_attached=False,
+        detector_reachable=False,
+        agent_spiffe_id=None,
+    )
+    assert hb.agent_spiffe_id is None
+
+
+# ---------------------------------------------------------------------------
+# 2. AuditEmitter.emit_heartbeat emits an 'enforcement_heartbeat' event
+# ---------------------------------------------------------------------------
+
+
+def test_emit_heartbeat_event_shape() -> None:
+    events: list[AuditEvent] = []
+    emitter = AuditEmitter(agent_id="agent-hb", sink=events.append)
+
+    emitter.emit_heartbeat(
+        effective_mode="enforce",
+        hooks_attached=True,
+        detector_reachable=True,
+        agent_spiffe_id=_SPIFFE,
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_type == "enforcement_heartbeat"
+    assert event.agent_id == "agent-hb"
+    assert event.attributes["effective_mode"] == "enforce"
+    assert event.attributes["hooks_attached"] is True
+    assert event.attributes["detector_reachable"] is True
+    assert event.attributes["agent_spiffe_id"] == _SPIFFE
+
+
+def test_emit_heartbeat_unattested_carries_none_spiffe() -> None:
+    events: list[AuditEvent] = []
+    emitter = AuditEmitter(agent_id="agent-hb", sink=events.append)
+
+    emitter.emit_heartbeat(
+        effective_mode="warn",
+        hooks_attached=False,
+        detector_reachable=False,
+        agent_spiffe_id=None,
+    )
+
+    assert events[-1].event_type == "enforcement_heartbeat"
+    assert events[-1].attributes["agent_spiffe_id"] is None
+    assert events[-1].attributes["hooks_attached"] is False
+    assert events[-1].attributes["detector_reachable"] is False
+
+
+# ---------------------------------------------------------------------------
+# 3. TrustRuntime.emit_heartbeat gathers live runtime state and emits it
+# ---------------------------------------------------------------------------
+
+
+def _constraints() -> AgentConstraints:
+    return AgentConstraints.model_validate(
+        {
+            "agent_id": "agent-1",
+            "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+            "tool_permissions": [],
+            "organization": {
+                "required_input_guards": [],
+                "required_output_guards": [],
+                "denied_tools": [],
+            },
+            "enforcement_mode": "enforce",
+            "updated_at": "2026-04-03T12:00:00+00:00",
+        }
+    )
+
+
+def _runtime(*, mode: str = "enforce") -> TrustRuntime:
+    client = MagicMock()
+    client._http._token = "test-api-key"  # api-key path -> unattested
+    client._http.get.return_value = _constraints().model_dump(mode="json")
+    return TrustRuntime(client=client, agent_id="agent-1", mode=mode)
+
+
+def test_runtime_emit_heartbeat_reports_effective_mode() -> None:
+    events: list[AuditEvent] = []
+    runtime = _runtime(mode="enforce")
+    runtime._audit._sink = events.append
+
+    runtime.emit_heartbeat()
+
+    assert events[-1].event_type == "enforcement_heartbeat"
+    assert events[-1].attributes["effective_mode"] == "enforce"
+
+
+def test_runtime_emit_heartbeat_reports_attested_spiffe_id() -> None:
+    events: list[AuditEvent] = []
+    runtime = _runtime()
+    runtime._identity = MagicMock()
+    runtime._identity.is_attested.return_value = True
+    runtime._identity.spiffe_id = _SPIFFE
+    runtime._audit._sink = events.append
+
+    runtime.emit_heartbeat()
+
+    assert events[-1].attributes["agent_spiffe_id"] == _SPIFFE
+
+
+def test_runtime_emit_heartbeat_no_guards_means_hooks_not_attached() -> None:
+    # No Dome guards configured (empty input/output guards) -> _dome is None.
+    events: list[AuditEvent] = []
+    runtime = _runtime()
+    runtime._audit._sink = events.append
+
+    runtime.emit_heartbeat()
+
+    assert events[-1].attributes["hooks_attached"] is False
+
+
+def test_runtime_emit_heartbeat_detector_unreachable_when_guards_disabled() -> None:
+    # A starved/failed detector backend sets _guards_disabled; the beacon must
+    # report detector_reachable=False so a silent downgrade is detectable.
+    events: list[AuditEvent] = []
+    runtime = _runtime()
+    runtime._guards_disabled = True
+    runtime._audit._sink = events.append
+
+    runtime.emit_heartbeat()
+
+    assert events[-1].attributes["detector_reachable"] is False
+
+
+def test_runtime_emit_heartbeat_returns_heartbeat_model() -> None:
+    runtime = _runtime()
+    hb = runtime.emit_heartbeat()
+    assert isinstance(hb, Heartbeat)
+    assert hb.effective_mode == "enforce"

--- a/vijil_dome/tests/trust/test_heartbeat_b3.py
+++ b/vijil_dome/tests/trust/test_heartbeat_b3.py
@@ -128,7 +128,7 @@ def _runtime(*, mode: str = "enforce") -> TrustRuntime:
     return TrustRuntime(client=client, agent_id="agent-1", mode=mode)
 
 
-def test_runtime_emit_heartbeat_reports_effective_mode() -> None:
+def test_runtime_emit_heartbeat_reports_configured_mode() -> None:
     events: list[AuditEvent] = []
     runtime = _runtime(mode="enforce")
     runtime._audit._sink = events.append
@@ -152,7 +152,7 @@ def test_runtime_emit_heartbeat_reports_attested_spiffe_id() -> None:
     assert events[-1].attributes["agent_spiffe_id"] == _SPIFFE
 
 
-def test_runtime_emit_heartbeat_no_guards_means_hooks_not_attached() -> None:
+def test_runtime_emit_heartbeat_no_guards_means_guards_not_constructed() -> None:
     # No Dome guards configured (empty input/output guards) -> _dome is None.
     events: list[AuditEvent] = []
     runtime = _runtime()

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -24,6 +24,31 @@ class AuditEvent(BaseModel):
     attributes: dict[str, Any]
 
 
+class Heartbeat(BaseModel):
+    """An enforcement-alive beacon: 'this agent is still enforcing'.
+
+    Emitted by a wrapped agent so a registered agent that goes dark or
+    silently downgrades its enforcement is detectable downstream. The
+    fields describe the live enforcement posture at emit time:
+
+    - ``effective_mode`` — the runtime's actual mode (``"warn"`` or
+      ``"enforce"``), so a silent downgrade from enforce to warn is visible.
+    - ``hooks_attached`` — whether the content guards are wired and live.
+    - ``detector_reachable`` — whether the detector backend is reachable; a
+      starved or failed detector flips this False without raising.
+    - ``agent_spiffe_id`` — the attested principal, or ``None`` when the
+      agent is unattested.
+
+    SVID-signing of the beacon and periodic scheduling are a follow-up; this
+    model is the unsigned event shape.
+    """
+
+    effective_mode: str
+    hooks_attached: bool
+    detector_reachable: bool
+    agent_spiffe_id: str | None
+
+
 class AuditEmitter:
     """Emits structured audit events to a pluggable sink.
 
@@ -80,6 +105,29 @@ class AuditEmitter:
             tool_name=tool_name,
             permitted=permitted,
             identity_verified=identity_verified,
+            agent_spiffe_id=agent_spiffe_id,
+        )
+
+    def emit_heartbeat(
+        self,
+        *,
+        effective_mode: str,
+        hooks_attached: bool,
+        detector_reachable: bool,
+        agent_spiffe_id: str | None = None,
+    ) -> None:
+        """Emit an enforcement-alive heartbeat ('I am enforcing') event.
+
+        Carries the live enforcement posture so a registered agent that goes
+        dark or silently downgrades is detectable downstream. See
+        ``Heartbeat`` for field semantics. SVID-signing of the beacon is a
+        follow-up; this emits the unsigned event shape.
+        """
+        self._emit(
+            "enforcement_heartbeat",
+            effective_mode=effective_mode,
+            hooks_attached=hooks_attached,
+            detector_reachable=detector_reachable,
             agent_spiffe_id=agent_spiffe_id,
         )
 

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -31,8 +31,6 @@ class Heartbeat(BaseModel):
     silently downgrades its enforcement is detectable downstream. The
     fields describe the live enforcement posture at emit time:
 
-    - ``effective_mode`` — the runtime's actual mode (``"warn"`` or
-      ``"enforce"``), so a silent downgrade from enforce to warn is visible.
     - ``configured_mode`` — the runtime's configured mode floor (``"warn"`` or
       ``"enforce"``), so a silent downgrade from enforce to warn is visible.
       Named *configured* rather than *effective* because the value reflects the

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -33,19 +33,28 @@ class Heartbeat(BaseModel):
 
     - ``effective_mode`` — the runtime's actual mode (``"warn"`` or
       ``"enforce"``), so a silent downgrade from enforce to warn is visible.
-    - ``hooks_attached`` — whether the content guards are wired and live.
-    - ``detector_reachable`` — whether the detector backend is reachable; a
-      starved or failed detector flips this False without raising.
-    - ``agent_spiffe_id`` — the attested principal, or ``None`` when the
-      agent is unattested.
+    - ``configured_mode`` — the runtime's configured mode floor (``"warn"`` or
+      ``"enforce"``), so a silent downgrade from enforce to warn is visible.
+      Named *configured* rather than *effective* because the value reflects the
+      constructor argument (after B5 floors it); it does not dynamically reflect
+      whether guards are currently running.
+    - ``guards_constructed`` — ``True`` when a ``Dome`` instance was successfully
+      built for this runtime. A proxy for "guards are in play"; it proves
+      construction, not that framework callbacks are actively wired.
+    - ``detector_reachable`` — ``False`` when no guards are configured or when the
+      detector backend failed/was starved; a reliable False-on-failure signal.
+    - ``attested`` — whether the agent's SPIFFE identity is attested at emit time.
+    - ``agent_spiffe_id`` — the attested principal SVID, or ``None`` when
+      ``attested`` is False. Consumers MUST gate on ``attested`` before keying
+      decisions on this value.
 
-    SVID-signing of the beacon and periodic scheduling are a follow-up; this
-    model is the unsigned event shape.
+    SVID-signing of the beacon and periodic scheduling are a follow-up (DOME-169).
     """
 
-    effective_mode: str
-    hooks_attached: bool
+    configured_mode: str
+    guards_constructed: bool
     detector_reachable: bool
+    attested: bool
     agent_spiffe_id: str | None
 
 
@@ -111,23 +120,24 @@ class AuditEmitter:
     def emit_heartbeat(
         self,
         *,
-        effective_mode: str,
-        hooks_attached: bool,
+        configured_mode: str,
+        guards_constructed: bool,
         detector_reachable: bool,
+        attested: bool,
         agent_spiffe_id: str | None = None,
     ) -> None:
         """Emit an enforcement-alive heartbeat ('I am enforcing') event.
 
         Carries the live enforcement posture so a registered agent that goes
         dark or silently downgrades is detectable downstream. See
-        ``Heartbeat`` for field semantics. SVID-signing of the beacon is a
-        follow-up; this emits the unsigned event shape.
+        ``Heartbeat`` for field semantics. SVID-signing is a follow-up (DOME-169).
         """
         self._emit(
             "enforcement_heartbeat",
-            effective_mode=effective_mode,
-            hooks_attached=hooks_attached,
+            configured_mode=configured_mode,
+            guards_constructed=guards_constructed,
             detector_reachable=detector_reachable,
+            attested=attested,
             agent_spiffe_id=agent_spiffe_id,
         )
 

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -629,15 +629,17 @@ class TrustRuntime:
         event and returns the ``Heartbeat`` model.
 
         ``hooks_attached`` is True only when a Dome instance was constructed
-        and guards are not disabled. ``detector_reachable`` is False when the
-        guards were disabled by a failed/starved detector backend, so a silent
-        downgrade is detectable downstream.
+        and guards are not disabled. ``detector_reachable`` is False when no
+        guards are configured (``_dome is None`` — there is no detector to
+        reach) OR the guards were disabled by a failed/starved detector
+        backend, so a silent downgrade is detectable downstream. A real
+        reachability probe (vs this proxy) is a follow-up (DOME-169).
 
         This is the event shape + emit. Periodic scheduling and SVID-signing
-        of the beacon are a follow-up (B3 part 2).
+        of the beacon are a follow-up (B3 part 2, DOME-169).
         """
         hooks_attached = self._dome is not None and not self._guards_disabled
-        detector_reachable = not self._guards_disabled
+        detector_reachable = self._dome is not None and not self._guards_disabled
         heartbeat = Heartbeat(
             effective_mode=self.mode,
             hooks_attached=hooks_attached,

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -623,9 +623,9 @@ class TrustRuntime:
     def emit_heartbeat(self) -> Heartbeat:
         """Emit an enforcement-alive beacon describing the live posture.
 
-        Gathers the runtime's effective mode, whether the content guards are
-        wired and live, whether the detector backend is reachable, and the
-        attested SPIFFE id, then emits an ``enforcement_heartbeat`` audit
+        Gathers the configured mode, whether guards were successfully constructed,
+        whether the detector backend is reachable, the attestation state, and the
+        agent SPIFFE id, then emits an ``enforcement_heartbeat`` audit
         event and returns the ``Heartbeat`` model.
 
         ``guards_constructed`` is True when a Dome instance was successfully

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from vijil_dome.controls.models import Control, EvaluationResult
 from vijil_dome.trust.attestation import AttestationResult, ToolAttestationStatus
-from vijil_dome.trust.audit import AuditEmitter, AuditEvent
+from vijil_dome.trust.audit import AuditEmitter, AuditEvent, Heartbeat
 from vijil_dome.trust.constraints import AgentConstraints
 from vijil_dome.trust.delta import (
     TrustDelta,
@@ -615,3 +615,39 @@ class TrustRuntime:
         except Exception as exc:
             logger.debug("Failed to extract SPIFFE ID from cert: %s", exc)
         return None
+
+    # ------------------------------------------------------------------
+    # Enforcement-alive heartbeat (B3)
+    # ------------------------------------------------------------------
+
+    def emit_heartbeat(self) -> Heartbeat:
+        """Emit an enforcement-alive beacon describing the live posture.
+
+        Gathers the runtime's effective mode, whether the content guards are
+        wired and live, whether the detector backend is reachable, and the
+        attested SPIFFE id, then emits an ``enforcement_heartbeat`` audit
+        event and returns the ``Heartbeat`` model.
+
+        ``hooks_attached`` is True only when a Dome instance was constructed
+        and guards are not disabled. ``detector_reachable`` is False when the
+        guards were disabled by a failed/starved detector backend, so a silent
+        downgrade is detectable downstream.
+
+        This is the event shape + emit. Periodic scheduling and SVID-signing
+        of the beacon are a follow-up (B3 part 2).
+        """
+        hooks_attached = self._dome is not None and not self._guards_disabled
+        detector_reachable = not self._guards_disabled
+        heartbeat = Heartbeat(
+            effective_mode=self.mode,
+            hooks_attached=hooks_attached,
+            detector_reachable=detector_reachable,
+            agent_spiffe_id=self._identity.spiffe_id,
+        )
+        self._audit.emit_heartbeat(
+            effective_mode=heartbeat.effective_mode,
+            hooks_attached=heartbeat.hooks_attached,
+            detector_reachable=heartbeat.detector_reachable,
+            agent_spiffe_id=heartbeat.agent_spiffe_id,
+        )
+        return heartbeat

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -628,28 +628,30 @@ class TrustRuntime:
         attested SPIFFE id, then emits an ``enforcement_heartbeat`` audit
         event and returns the ``Heartbeat`` model.
 
-        ``hooks_attached`` is True only when a Dome instance was constructed
-        and guards are not disabled. ``detector_reachable`` is False when no
-        guards are configured (``_dome is None`` — there is no detector to
-        reach) OR the guards were disabled by a failed/starved detector
-        backend, so a silent downgrade is detectable downstream. A real
-        reachability probe (vs this proxy) is a follow-up (DOME-169).
+        ``guards_constructed`` is True when a Dome instance was successfully
+        built; it proves construction, not that framework callbacks are wired.
+        ``detector_reachable`` is False when no guards are configured or when
+        the backend failed/was starved. ``attested`` gates the SPIFFE id:
+        ``agent_spiffe_id`` is only meaningful when ``attested`` is True.
 
-        This is the event shape + emit. Periodic scheduling and SVID-signing
-        of the beacon are a follow-up (B3 part 2, DOME-169).
+        A real detector reachability probe, SVID-signing, and periodic
+        scheduling are a follow-up (DOME-169).
         """
-        hooks_attached = self._dome is not None and not self._guards_disabled
+        attested = self._identity.is_attested()
+        guards_constructed = self._dome is not None and not self._guards_disabled
         detector_reachable = self._dome is not None and not self._guards_disabled
         heartbeat = Heartbeat(
-            effective_mode=self.mode,
-            hooks_attached=hooks_attached,
+            configured_mode=self.mode,
+            guards_constructed=guards_constructed,
             detector_reachable=detector_reachable,
-            agent_spiffe_id=self._identity.spiffe_id,
+            attested=attested,
+            agent_spiffe_id=self._identity.spiffe_id if attested else None,
         )
         self._audit.emit_heartbeat(
-            effective_mode=heartbeat.effective_mode,
-            hooks_attached=heartbeat.hooks_attached,
+            configured_mode=heartbeat.configured_mode,
+            guards_constructed=heartbeat.guards_constructed,
             detector_reachable=heartbeat.detector_reachable,
+            attested=heartbeat.attested,
             agent_spiffe_id=heartbeat.agent_spiffe_id,
         )
         return heartbeat


### PR DESCRIPTION
## What

B3 of the tamper-evident in-process identity-MAC effort (DOME-163): an **enforcement-alive heartbeat**. A wrapped agent emits a "I am enforcing" beacon so a registered agent that goes dark or silently downgrades its enforcement is detectable downstream.

## Changes (3 files, +260/-1)

- **`Heartbeat` pydantic model** (`trust/audit.py`) — the unsigned event shape: `effective_mode: str`, `hooks_attached: bool`, `detector_reachable: bool`, `agent_spiffe_id: str | None`.
- **`AuditEmitter.emit_heartbeat(...)`** — emits an `'enforcement_heartbeat'` audit event, mirroring the existing `emit_tool_mac`/`_emit` pattern.
- **`TrustRuntime.emit_heartbeat()`** — one new method (appended at the end of the class) that gathers the live posture and emits the beacon:
  - `effective_mode` ← `self.mode`
  - `hooks_attached` ← Dome instance constructed **and** guards not disabled
  - `detector_reachable` ← `not self._guards_disabled` (a starved/failed detector backend disabled the guards, so this flips `False` rather than failing open silently)
  - `agent_spiffe_id` ← `self._identity.spiffe_id`

## Scope (tight, per the plan)

This is the **event shape + emit only**. The periodic scheduler and **SVID-signing** of the beacon are a deliberate **follow-up (B3 part 2)** — noted in the model and method docstrings. Per the threat-model/plan doc, the SVID-signed/TEE-quote beacon and the Console liveness reconciler (B4) build on this shape.

The `runtime.py` change is a **single new method appended at the end of `TrustRuntime`** (plus one import-line addition) to minimize conflict with the parallel enforcement-cluster edits to the same file.

## Tests (TDD)

`vijil_dome/tests/trust/test_heartbeat_b3.py` — 9 tests, written failing first:
- `Heartbeat` model field round-trip + optional `agent_spiffe_id`
- `AuditEmitter.emit_heartbeat` event shape (attested + unattested)
- `TrustRuntime.emit_heartbeat` reports effective mode, attested SPIFFE id, `hooks_attached=False` when no guards, `detector_reachable=False` when `_guards_disabled`, and returns a `Heartbeat`

## Gates

- `ruff check vijil_dome/` — clean
- `mypy vijil_dome/trust/audit.py vijil_dome/trust/runtime.py` — clean
- `pytest` — 9 new B3 tests pass; full trust-core suite 140 passed (1 pre-existing, env-dependent presidio failure in `test_console_constraints` confirmed present on clean `main` — not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)