### PR TITLE
feat(dome): identity-keyed enforcement — unattested-deny, SVID-binding, enforce-floor [DOME-163]

### DIFF
--- a/vijil_dome/tests/trust/test_identity_mac_a2.py
+++ b/vijil_dome/tests/trust/test_identity_mac_a2.py
@@ -1,0 +1,79 @@
+"""A2 (DOME-163): fail-closed on an unattested identity, gated by ``unattested_tool_policy``.
+
+The flag controls the DECISION (deny an unattested agent's tool calls); ``enforcement_mode``
+controls whether that deny is ENFORCED (the existing pattern). Default is ``warn`` so existing
+enforce-mode-but-unattested flows are not silently bricked; ``deny`` is the secure opt-in.
+"""
+
+from __future__ import annotations
+
+from vijil_dome.trust.constraints import AgentConstraints
+from vijil_dome.trust.policy import ToolPolicy
+
+_SPIFFE = "spiffe://vijil.ai/org/team-1/agent/agent-1"
+
+
+def _constraints(*, enforcement_mode: str = "enforce", unattested_tool_policy: str = "warn") -> AgentConstraints:
+    return AgentConstraints.model_validate(
+        {
+            "agent_id": "agent-1",
+            "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+            "tool_permissions": [
+                {"name": "book_flight", "identity": "spiffe://vijil.ai/tools/book_flight/v1",
+                 "endpoint": "mcp+tls://book_flight.internal:8443"},
+            ],
+            "organization": {"required_input_guards": [], "required_output_guards": [], "denied_tools": []},
+            "enforcement_mode": enforcement_mode,
+            "unattested_tool_policy": unattested_tool_policy,
+            "updated_at": "2026-04-03T12:00:00+00:00",
+        }
+    )
+
+
+def test_unattested_denied_under_deny_policy() -> None:
+    result = ToolPolicy(_constraints(unattested_tool_policy="deny")).check(
+        "book_flight", {}, spiffe_id=None, attested=False
+    )
+    assert result.permitted is False
+    assert "attest" in (result.error or "").lower()
+    assert result.enforced is True  # enforce mode -> the deny is enforced
+
+
+def test_attested_permitted_under_deny_policy() -> None:
+    result = ToolPolicy(_constraints(unattested_tool_policy="deny")).check(
+        "book_flight", {}, spiffe_id=_SPIFFE, attested=True
+    )
+    assert result.permitted is True
+    assert result.identity_verified is True
+
+
+def test_unattested_permitted_under_warn_policy_backcompat() -> None:
+    # Default warn-policy preserves today's behavior: unattested still gets the normal tool check.
+    result = ToolPolicy(_constraints(unattested_tool_policy="warn")).check(
+        "book_flight", {}, spiffe_id=None, attested=False
+    )
+    assert result.permitted is True
+
+
+def test_unattested_deny_decision_not_enforced_in_warn_mode() -> None:
+    # warn enforcement mode computes the deny but does not enforce it (logged, not blocked).
+    result = ToolPolicy(_constraints(enforcement_mode="warn", unattested_tool_policy="deny")).check(
+        "book_flight", {}, spiffe_id=None, attested=False
+    )
+    assert result.permitted is False  # policy decides deny
+    assert result.enforced is False  # warn mode does not enforce
+
+
+def test_default_unattested_policy_is_warn() -> None:
+    # Omitting the field defaults to warn (no unattested deny) — non-bricking.
+    constraints = AgentConstraints.model_validate(
+        {
+            "agent_id": "agent-1",
+            "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+            "tool_permissions": [],
+            "organization": {"required_input_guards": [], "required_output_guards": [], "denied_tools": []},
+            "enforcement_mode": "enforce",
+            "updated_at": "2026-04-03T12:00:00+00:00",
+        }
+    )
+    assert constraints.unattested_tool_policy == "warn"

--- a/vijil_dome/tests/trust/test_identity_mac_a3.py
+++ b/vijil_dome/tests/trust/test_identity_mac_a3.py
@@ -58,10 +58,22 @@ def test_legacy_uuid_keyed_constraints_skip_binding() -> None:
     assert result.permitted is True
 
 
-def test_unattested_does_not_trigger_binding_check() -> None:
-    # An unattested agent is governed by A2's unattested policy, not the binding check; default
-    # unattested_tool_policy='warn' means the normal tool check applies.
+def test_unattested_svid_keyed_permitted_under_default_warn_policy() -> None:
+    # DOCUMENTED STAGED GAP: an unattested agent against an SVID-keyed policy is governed by A2's
+    # unattested_tool_policy. The default "warn" permits it (non-bricking — many agents run
+    # unattested today since X.509 attestation isn't reliably wired). To enforce binding for
+    # unattested agents, set unattested_tool_policy="deny" (next test). FOLLOW-UP: flip the
+    # default to fail-closed once attestation is the norm (paired with the A2 default-flip).
     result = ToolPolicy(_constraints(subject=_SPIFFE)).check(
         "book_flight", {}, spiffe_id=None, attested=False
     )
     assert result.permitted is True
+
+
+def test_unattested_svid_keyed_denied_when_policy_deny() -> None:
+    # The secure config closes the gap: deny-policy denies an unattested agent regardless of
+    # subject shape (A2), so an SVID-keyed policy with deny is fully identity-bound.
+    constraints = _constraints(subject=_SPIFFE).model_copy(update={"unattested_tool_policy": "deny"})
+    result = ToolPolicy(constraints).check("book_flight", {}, spiffe_id=None, attested=False)
+    assert result.permitted is False
+    assert "attest" in (result.error or "").lower()

--- a/vijil_dome/tests/trust/test_identity_mac_a3.py
+++ b/vijil_dome/tests/trust/test_identity_mac_a3.py
@@ -1,0 +1,67 @@
+"""A3 (DOME-163): bind the policy to the attested principal.
+
+When an agent is attested AND its constraints are SVID-keyed (subject is a ``spiffe://`` URI),
+the attested SVID MUST equal the policy subject — otherwise the loaded constraints belong to a
+different identity (the priv-esc the threat model flags: load any agent's constraints with an
+API token) and the call fails closed. Auto-applies only to SVID-keyed constraints; legacy
+UUID-keyed constraints skip the check (non-bricking). The production source of SVID-keyed
+constraints is Console (A9, next week); the dome enforcement point lands here now.
+"""
+
+from __future__ import annotations
+
+from vijil_dome.trust.constraints import AgentConstraints
+from vijil_dome.trust.policy import ToolPolicy
+
+_SPIFFE = "spiffe://vijil.ai/org/team-1/agent/agent-1"
+_OTHER_SPIFFE = "spiffe://vijil.ai/org/team-1/agent/agent-99"
+
+
+def _constraints(*, subject: str) -> AgentConstraints:
+    return AgentConstraints.model_validate(
+        {
+            "agent_id": subject,
+            "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+            "tool_permissions": [
+                {"name": "book_flight", "identity": "spiffe://vijil.ai/tools/book_flight/v1",
+                 "endpoint": "mcp+tls://book_flight.internal:8443"},
+            ],
+            "organization": {"required_input_guards": [], "required_output_guards": [], "denied_tools": []},
+            "enforcement_mode": "enforce",
+            "updated_at": "2026-04-03T12:00:00+00:00",
+        }
+    )
+
+
+def test_svid_matches_policy_subject_permitted() -> None:
+    result = ToolPolicy(_constraints(subject=_SPIFFE)).check(
+        "book_flight", {}, spiffe_id=_SPIFFE, attested=True
+    )
+    assert result.permitted is True
+
+
+def test_svid_mismatch_policy_subject_denied() -> None:
+    # Attested as agent-1 but the loaded constraints are for agent-99 -> fail closed.
+    result = ToolPolicy(_constraints(subject=_OTHER_SPIFFE)).check(
+        "book_flight", {}, spiffe_id=_SPIFFE, attested=True
+    )
+    assert result.permitted is False
+    assert "match" in (result.error or "").lower()
+    assert result.enforced is True
+
+
+def test_legacy_uuid_keyed_constraints_skip_binding() -> None:
+    # Subject is a UUID (not spiffe://) -> legacy path, binding check does not apply (non-bricking).
+    result = ToolPolicy(_constraints(subject="agent-uuid-123")).check(
+        "book_flight", {}, spiffe_id=_SPIFFE, attested=True
+    )
+    assert result.permitted is True
+
+
+def test_unattested_does_not_trigger_binding_check() -> None:
+    # An unattested agent is governed by A2's unattested policy, not the binding check; default
+    # unattested_tool_policy='warn' means the normal tool check applies.
+    result = ToolPolicy(_constraints(subject=_SPIFFE)).check(
+        "book_flight", {}, spiffe_id=None, attested=False
+    )
+    assert result.permitted is True

--- a/vijil_dome/tests/trust/test_identity_mac_b5.py
+++ b/vijil_dome/tests/trust/test_identity_mac_b5.py
@@ -57,3 +57,33 @@ def test_no_downgrade_event_when_not_downgrading() -> None:
     events: list[AuditEvent] = []
     _runtime(console_mode="warn", local_mode="enforce", sink=events.append)
     assert [e for e in events if e.event_type == "mode_downgrade"] == []
+
+
+def test_dome_init_failure_under_mandated_enforce_raises(monkeypatch: object) -> None:
+    """The Dome-init exception handler must gate on effective_mode, not the raw local mode.
+
+    Console mandates enforce, the caller passes warn → effective_mode is enforce. If Dome
+    construction fails, the runtime must RAISE (fail-closed) rather than silently disable guards
+    — the downgrade-via-error-path the enforcement-core review flagged as critical.
+    """
+    import pytest
+    import vijil_dome
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise ValueError("bad guard config")
+
+    monkeypatch.setattr(vijil_dome, "Dome", _boom)  # type: ignore[attr-defined]
+    constraints = {
+        "agent_id": "agent-1",
+        "dome_config": {"input_guards": ["prompt_injection"], "output_guards": [],
+                        "guards": {"prompt_injection": {}}},
+        "tool_permissions": [],
+        "organization": {"required_input_guards": [], "required_output_guards": [], "denied_tools": []},
+        "enforcement_mode": "enforce",
+        "updated_at": "2026-04-03T12:00:00+00:00",
+    }
+    client = MagicMock()
+    client._http._token = "test-api-key"
+    client._http.get.return_value = constraints
+    with pytest.raises(RuntimeError, match="enforce"):
+        TrustRuntime(client=client, agent_id="agent-1", mode="warn")  # local warn, mandated enforce

--- a/vijil_dome/tests/trust/test_identity_mac_b5.py
+++ b/vijil_dome/tests/trust/test_identity_mac_b5.py
@@ -1,0 +1,59 @@
+"""B5 (DOME-163): enforce is a floor — a local ``mode='warn'`` must not silently downgrade a
+Console- (or constraint-) mandated ``enforce``. The downgrade attempt is audited, not honored.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+from vijil_dome.trust.audit import AuditEvent
+from vijil_dome.trust.runtime import TrustRuntime
+
+
+def _runtime(
+    *, console_mode: str, local_mode: str, sink: Callable[[AuditEvent], None] | None = None
+) -> TrustRuntime:
+    constraints = {
+        "agent_id": "agent-1",
+        "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+        "tool_permissions": [],
+        "organization": {"required_input_guards": [], "required_output_guards": [], "denied_tools": []},
+        "enforcement_mode": console_mode,
+        "updated_at": "2026-04-03T12:00:00+00:00",
+    }
+    client = MagicMock()
+    client._http._token = "test-api-key"
+    client._http.get.return_value = constraints
+    return TrustRuntime(client=client, agent_id="agent-1", mode=local_mode, audit_sink=sink)
+
+
+def test_console_enforce_floors_a_local_warn() -> None:
+    assert _runtime(console_mode="enforce", local_mode="warn").mode == "enforce"
+
+
+def test_local_enforce_upgrades_a_console_warn() -> None:
+    assert _runtime(console_mode="warn", local_mode="enforce").mode == "enforce"
+
+
+def test_both_warn_stays_warn() -> None:
+    assert _runtime(console_mode="warn", local_mode="warn").mode == "warn"
+
+
+def test_both_enforce_stays_enforce() -> None:
+    assert _runtime(console_mode="enforce", local_mode="enforce").mode == "enforce"
+
+
+def test_downgrade_attempt_is_audited() -> None:
+    events: list[AuditEvent] = []
+    _runtime(console_mode="enforce", local_mode="warn", sink=events.append)
+    downgrades = [e for e in events if e.event_type == "mode_downgrade"]
+    assert len(downgrades) == 1
+    assert downgrades[0].attributes["requested"] == "warn"
+    assert downgrades[0].attributes["effective"] == "enforce"
+
+
+def test_no_downgrade_event_when_not_downgrading() -> None:
+    events: list[AuditEvent] = []
+    _runtime(console_mode="warn", local_mode="enforce", sink=events.append)
+    assert [e for e in events if e.event_type == "mode_downgrade"] == []

--- a/vijil_dome/tests/trust/test_identity_mac_e2e.py
+++ b/vijil_dome/tests/trust/test_identity_mac_e2e.py
@@ -1,0 +1,134 @@
+"""End-to-end identity-MAC enforcement through TrustRuntime (not just ToolPolicy).
+
+varunc1996 review of #248: A2/A3 tests drive ToolPolicy.check directly; no test
+exercises check_tool_call / wrap_tool raising PermissionError on an
+identity-grounds denial in enforce mode — the integration that would catch
+mode-vs-enforced flag drift.
+
+These tests confirm:
+- check_tool_call returns a denied result with enforced=True
+- wrap_tool raises PermissionError in enforce mode
+- audit emits svid_keyed_unattested when an SVID-keyed policy is evaluated for
+  an unattested caller under the default "warn" (makes the residual exposure
+  visible).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from vijil_dome.trust.audit import AuditEvent
+from vijil_dome.trust.runtime import TrustRuntime
+
+_SUBJECT = "spiffe://vijil.ai/org/team-1/agent/agent-1"
+_OTHER = "spiffe://vijil.ai/org/team-1/agent/agent-99"
+
+
+def _constraints(*, unattested_tool_policy: str = "deny", enforcement_mode: str = "enforce") -> dict:
+    return {
+        "agent_id": _SUBJECT,
+        "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+        "tool_permissions": [
+            {
+                "name": "book_flight",
+                "identity": "spiffe://vijil.ai/tools/book_flight/v1",
+                "endpoint": "mcp+tls://book_flight.internal:8443",
+            }
+        ],
+        "organization": {"required_input_guards": [], "required_output_guards": [], "denied_tools": []},
+        "enforcement_mode": enforcement_mode,
+        "unattested_tool_policy": unattested_tool_policy,
+        "updated_at": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+
+def _runtime(c: dict, *, sid: str | None, att: bool) -> TrustRuntime:
+    rt = TrustRuntime(agent_id="agent-1", mode="enforce", constraints=c)
+    rt._identity = SimpleNamespace(is_attested=lambda: att, spiffe_id=sid)
+    return rt
+
+
+def _tool(name: str = "book_flight"):
+    def fn(**kwargs): return "ok"  # noqa: E704
+    fn.__name__ = name
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# check_tool_call e2e — A2 unattested + deny policy
+# ---------------------------------------------------------------------------
+
+
+def test_check_tool_call_a2_deny_returns_enforced_denied() -> None:
+    result = _runtime(_constraints(unattested_tool_policy="deny"), sid=None, att=False).check_tool_call(
+        "book_flight", {}
+    )
+    assert result.permitted is False
+    assert result.enforced is True  # enforced=True because enforcement_mode is "enforce"
+    assert "attest" in (result.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# wrap_tool e2e — raises PermissionError on identity-grounds denial
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_tool_a2_deny_raises_permission_error() -> None:
+    rt = _runtime(_constraints(unattested_tool_policy="deny"), sid=None, att=False)
+    with pytest.raises(PermissionError, match="book_flight"):
+        rt.wrap_tool(_tool("book_flight"))()
+
+
+def test_wrap_tool_a3_svid_mismatch_raises_permission_error() -> None:
+    rt = _runtime(_constraints(), sid=_OTHER, att=True)
+    with pytest.raises(PermissionError, match="book_flight"):
+        rt.wrap_tool(_tool("book_flight"))()
+
+
+def test_wrap_tool_a3_svid_match_permits() -> None:
+    rt = _runtime(_constraints(), sid=_SUBJECT, att=True)
+    assert rt.wrap_tool(_tool("book_flight"))() == "ok"
+
+
+def test_wrap_tool_warn_mode_does_not_raise() -> None:
+    c = _constraints(unattested_tool_policy="deny", enforcement_mode="warn")
+    rt = TrustRuntime(agent_id="agent-1", mode="warn", constraints=c)
+    rt._identity = SimpleNamespace(is_attested=lambda: False, spiffe_id=None)
+    # Both constraint enforcement_mode and runtime mode are "warn" -> enforced=False -> no raise.
+    result = rt.check_tool_call("book_flight", {})
+    assert result.permitted is False
+    assert result.enforced is False
+    # wrap_tool must NOT raise when enforced=False
+    rt.wrap_tool(_tool("book_flight"))()
+
+
+# ---------------------------------------------------------------------------
+# Audit: svid_keyed_unattested event when SVID-keyed policy + unattested + warn
+# ---------------------------------------------------------------------------
+
+
+def test_svid_keyed_unattested_audit_event_emitted() -> None:
+    events: list[AuditEvent] = []
+    rt = _runtime(_constraints(unattested_tool_policy="warn"), sid=None, att=False)
+    rt._audit._sink = events.append
+
+    result = rt.check_tool_call("book_flight", {})
+
+    assert result.permitted is True  # default warn -> permitted (DOME-166 will flip)
+    svid_events = [e for e in events if e.event_type == "svid_keyed_unattested"]
+    assert len(svid_events) == 1
+    assert svid_events[0].attributes["tool_name"] == "book_flight"
+    assert svid_events[0].attributes["policy_subject"] == _SUBJECT
+
+
+def test_svid_keyed_unattested_not_emitted_when_attested() -> None:
+    events: list[AuditEvent] = []
+    rt = _runtime(_constraints(unattested_tool_policy="warn"), sid=_SUBJECT, att=True)
+    rt._audit._sink = events.append
+
+    rt.check_tool_call("book_flight", {})
+
+    assert not any(e.event_type == "svid_keyed_unattested" for e in events)

--- a/vijil_dome/tests/trust/test_identity_mac_e2e.py
+++ b/vijil_dome/tests/trust/test_identity_mac_e2e.py
@@ -47,7 +47,7 @@ def _constraints(*, unattested_tool_policy: str = "deny", enforcement_mode: str 
 
 def _runtime(c: dict, *, sid: str | None, att: bool) -> TrustRuntime:
     rt = TrustRuntime(agent_id="agent-1", mode="enforce", constraints=c)
-    rt._identity = SimpleNamespace(is_attested=lambda: att, spiffe_id=sid)
+    rt._identity = SimpleNamespace(is_attested=lambda: att, spiffe_id=sid)  # type: ignore[assignment]
     return rt
 
 
@@ -96,7 +96,7 @@ def test_wrap_tool_a3_svid_match_permits() -> None:
 def test_wrap_tool_warn_mode_does_not_raise() -> None:
     c = _constraints(unattested_tool_policy="deny", enforcement_mode="warn")
     rt = TrustRuntime(agent_id="agent-1", mode="warn", constraints=c)
-    rt._identity = SimpleNamespace(is_attested=lambda: False, spiffe_id=None)
+    rt._identity = SimpleNamespace(is_attested=lambda: False, spiffe_id=None)  # type: ignore[assignment]
     # Both constraint enforcement_mode and runtime mode are "warn" -> enforced=False -> no raise.
     result = rt.check_tool_call("book_flight", {})
     assert result.permitted is False

--- a/vijil_dome/tests/trust/test_policy.py
+++ b/vijil_dome/tests/trust/test_policy.py
@@ -203,6 +203,18 @@ def test_none_action_denied_when_allowed_actions_set() -> None:
     assert "not in allowed_actions" in (result.error or "")
 
 
+def test_none_args_denied_when_allowed_actions_set() -> None:
+    # Fail-open regression (DOME-163, varunc1996 review of #244/#248): args=None — the whole
+    # dict, not just a missing "action" key — must still fail closed when the tool restricts
+    # allowed_actions. The action cannot be satisfied without args, so it is denied. The prior
+    # guard `and args is not None` skipped the check entirely and PERMITTED the call.
+    policy = ToolPolicy(_make_constraints_with_allowed_actions(["read"]))
+    result = policy.check("file_tool", args=None)
+
+    assert result.permitted is False
+    assert "not in allowed_actions" in (result.error or "")
+
+
 def test_valid_action_permitted() -> None:
     policy = ToolPolicy(_make_constraints_with_allowed_actions(["read", "write"]))
     result = policy.check("file_tool", args={"action": "read"})

--- a/vijil_dome/trust/adapters/adk.py
+++ b/vijil_dome/trust/adapters/adk.py
@@ -147,7 +147,7 @@ def secure_agent(
         tool_name = getattr(tool, "name", getattr(tool, "__name__", str(tool)))
         mac_result = runtime.check_tool_call(tool_name, args)
 
-        if not mac_result.permitted and runtime.mode == "enforce":
+        if not mac_result.permitted and mac_result.enforced:
             # Return a dict to short-circuit the tool call
             return {"error": f"Tool '{tool_name}' denied: {mac_result.error}"}
         if not mac_result.permitted:

--- a/vijil_dome/trust/adapters/strands.py
+++ b/vijil_dome/trust/adapters/strands.py
@@ -208,7 +208,7 @@ def create_trust_hooks(
 
             mac_result = runtime.check_tool_call(tool_name, dict(tool_use.get("input", {})))
 
-            if not mac_result.permitted and runtime.mode == "enforce":
+            if not mac_result.permitted and mac_result.enforced:
                 event.cancel_tool = f"Tool '{tool_name}' denied: {mac_result.error}"
                 logger.warning("Tool '%s' blocked (enforce mode)", tool_name)
             elif not mac_result.permitted:

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -109,6 +109,23 @@ class AuditEmitter:
             error=error,
         )
 
+    def emit_mode_downgrade(
+        self,
+        *,
+        requested: str,
+        effective: str,
+    ) -> None:
+        """Emit an enforcement-mode downgrade event.
+
+        Records that a weaker local mode (``requested``) was overridden by a stronger
+        mandated mode (``effective``) — enforce is a floor that cannot be silently downgraded.
+        """
+        self._emit(
+            "mode_downgrade",
+            requested=requested,
+            effective=effective,
+        )
+
     def emit_guards_disabled(
         self,
         *,

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -126,6 +126,29 @@ class AuditEmitter:
             effective=effective,
         )
 
+    def emit_svid_keyed_unattested(
+        self,
+        tool_name: str,
+        *,
+        policy_subject: str,
+    ) -> None:
+        """Emit an audit event when an SVID-keyed policy is evaluated for an unattested caller.
+
+        A3 binding only applies to attested callers; an unattested caller passes through
+        without identity verification even when the policy subject is a ``spiffe://`` URI.
+        This event makes that residual exposure visible in the audit stream so operators
+        can detect and alert on it — without a distinct audit event, the permitted call is
+        indistinguishable from a legitimately-attested call.
+
+        Close this gap fully by setting ``unattested_tool_policy="deny"`` (A2), or by
+        flipping the default once attestation is the norm (DOME-166).
+        """
+        self._emit(
+            "svid_keyed_unattested",
+            tool_name=tool_name,
+            policy_subject=policy_subject,
+        )
+
     def emit_guards_disabled(
         self,
         *,

--- a/vijil_dome/trust/constraints.py
+++ b/vijil_dome/trust/constraints.py
@@ -46,5 +46,11 @@ class AgentConstraints(BaseModel):
     # (the normal tool check applies) so existing enforce-mode-but-unattested flows are not
     # bricked; "deny" fails closed — an unattested agent is denied regardless of tool. The flag
     # sets the DECISION; enforcement_mode decides whether that deny is enforced.
+    #
+    # SVID-keyed policies: when agent_id is a spiffe:// subject, the A3 binding check rejects an
+    # ATTESTED agent whose SVID differs from the subject. But an UNATTESTED agent cannot be bound
+    # (there is no SVID to compare), so binding an identity-keyed policy against unattested callers
+    # requires unattested_tool_policy="deny" — the default "warn" lets an unattested agent through
+    # the normal tool check. FOLLOW-UP: flip this default to "deny" once attestation is the norm.
     unattested_tool_policy: Literal["warn", "deny"] = "warn"
     updated_at: datetime

--- a/vijil_dome/trust/constraints.py
+++ b/vijil_dome/trust/constraints.py
@@ -42,4 +42,9 @@ class AgentConstraints(BaseModel):
     tool_permissions: list[ToolPermission]
     organization: OrganizationConstraints
     enforcement_mode: Literal["warn", "enforce"]
+    # How to treat an UNATTESTED agent's tool calls. "warn" (default) preserves today's behavior
+    # (the normal tool check applies) so existing enforce-mode-but-unattested flows are not
+    # bricked; "deny" fails closed — an unattested agent is denied regardless of tool. The flag
+    # sets the DECISION; enforcement_mode decides whether that deny is enforced.
+    unattested_tool_policy: Literal["warn", "deny"] = "warn"
     updated_at: datetime

--- a/vijil_dome/trust/policy.py
+++ b/vijil_dome/trust/policy.py
@@ -115,9 +115,12 @@ class ToolPolicy:
             )
 
         # Check allowed_actions if the permission restricts them.
-        # Fail-closed: missing or None action is denied when allowed_actions is set.
-        if perm.allowed_actions is not None and args is not None:
-            action = args.get("action")
+        # Fail-closed: a missing or None action is denied when allowed_actions is set —
+        # including args=None (no action can be satisfied without args, so it is denied,
+        # not skipped). Gating on `args is not None` here would PERMIT a restricted tool
+        # called with no args, a fail-open in the MAC path.
+        if perm.allowed_actions is not None:
+            action = args.get("action") if args is not None else None
             if action is None or action not in perm.allowed_actions:
                 return self._deny(
                     tool_name,

--- a/vijil_dome/trust/policy.py
+++ b/vijil_dome/trust/policy.py
@@ -25,10 +25,13 @@ class ToolPolicy:
     """Mandatory Access Control policy derived from AgentConstraints.
 
     Checks whether an agent is permitted to call a named tool by:
-    1. Rejecting tools denied at the organization level.
-    2. Rejecting tools absent from the agent's explicit permission list.
-    3. Checking allowed_actions if the permission restricts specific actions.
-    4. Honouring the enforcement mode — enforced=True only when the call
+    1. Denying an unattested agent when ``unattested_tool_policy`` is "deny" (A2).
+    2. Denying an attested agent whose SVID does not match an SVID-keyed
+       policy subject (A3 binding check).
+    3. Rejecting tools denied at the organization level.
+    4. Rejecting tools absent from the agent's explicit permission list.
+    5. Checking allowed_actions if the permission restricts specific actions.
+    6. Honouring the enforcement mode — enforced=True only when the call
        would be blocked AND the mode is "enforce".
     """
 
@@ -63,15 +66,16 @@ class ToolPolicy:
                 potential downstream audit/debugging (not emitted today); future
                 versions may enforce parameter-level constraints (e.g., allowed
                 parameter ranges, required fields).
-            spiffe_id: The calling agent's SPIFFE ID, recorded on the result for
-                audit. Threaded for downstream identity-keyed policy (A2/A3); the
-                permit/deny outcome is NOT keyed on it here. It is recorded even
-                when ``attested`` is False, so consumers MUST gate on
-                ``identity_verified`` before keying any decision on it.
+            spiffe_id: The calling agent's SPIFFE ID. For an SVID-keyed policy
+                subject, the A3 binding check denies an ATTESTED call whose
+                ``spiffe_id`` differs from the subject — so the permit/deny outcome
+                IS keyed on it for attested callers. It is also recorded on the
+                result for audit. An unattested caller has no verified SVID, so the
+                binding check applies only when ``attested`` is True.
             attested: Whether the agent's identity is attested. Recorded as
                 ``identity_verified``. When ``unattested_tool_policy`` is "deny", an
-                unattested agent is denied here (fail-closed); enforcement_mode then
-                decides whether that deny is enforced or only logged.
+                unattested agent is denied here (A2, fail-closed); enforcement_mode
+                then decides whether that deny is enforced or only logged.
         """
         # A2: fail-closed on an unattested identity when the operator opted into "deny".
         # An unattested agent is denied regardless of which tool it calls.

--- a/vijil_dome/trust/policy.py
+++ b/vijil_dome/trust/policy.py
@@ -41,6 +41,7 @@ class ToolPolicy:
         )
         self._enforcement_mode: str = constraints.enforcement_mode
         self._unattested_tool_policy: str = constraints.unattested_tool_policy
+        self._subject: str = constraints.agent_id
 
     # ------------------------------------------------------------------
     # Public API
@@ -78,6 +79,19 @@ class ToolPolicy:
             return self._deny(
                 tool_name,
                 "agent identity is not attested",
+                args,
+                spiffe_id=spiffe_id,
+                attested=attested,
+            )
+
+        # A3: an attested agent must match the SVID-keyed policy subject. A mismatch means the
+        # loaded constraints belong to a different identity (the "load any agent's constraints
+        # with an API token" priv-esc) -> fail closed. Applies only to SVID-keyed constraints
+        # (subject is a spiffe:// URI); legacy UUID-keyed constraints skip it (non-bricking).
+        if attested and self._subject.startswith("spiffe://") and spiffe_id != self._subject:
+            return self._deny(
+                tool_name,
+                "attested identity does not match the policy subject",
                 args,
                 spiffe_id=spiffe_id,
                 attested=attested,

--- a/vijil_dome/trust/policy.py
+++ b/vijil_dome/trust/policy.py
@@ -40,6 +40,7 @@ class ToolPolicy:
             constraints.organization.denied_tools
         )
         self._enforcement_mode: str = constraints.enforcement_mode
+        self._unattested_tool_policy: str = constraints.unattested_tool_policy
 
     # ------------------------------------------------------------------
     # Public API
@@ -67,8 +68,21 @@ class ToolPolicy:
                 when ``attested`` is False, so consumers MUST gate on
                 ``identity_verified`` before keying any decision on it.
             attested: Whether the agent's identity is attested. Recorded as
-                ``identity_verified``; does not change the outcome in this step.
+                ``identity_verified``. When ``unattested_tool_policy`` is "deny", an
+                unattested agent is denied here (fail-closed); enforcement_mode then
+                decides whether that deny is enforced or only logged.
         """
+        # A2: fail-closed on an unattested identity when the operator opted into "deny".
+        # An unattested agent is denied regardless of which tool it calls.
+        if not attested and self._unattested_tool_policy == "deny":
+            return self._deny(
+                tool_name,
+                "agent identity is not attested",
+                args,
+                spiffe_id=spiffe_id,
+                attested=attested,
+            )
+
         if tool_name in self._denied_tools:
             return self._deny(
                 tool_name, "denied by organization constraints", args,

--- a/vijil_dome/trust/policy.py
+++ b/vijil_dome/trust/policy.py
@@ -143,6 +143,20 @@ class ToolPolicy:
         """Return the ToolPermission entry for *tool_name*, or None if absent."""
         return self._permissions.get(tool_name)
 
+    def is_svid_keyed(self) -> bool:
+        """Return True when the policy subject is a SPIFFE ID (``spiffe://`` prefix).
+
+        The A3 binding check only fires for SVID-keyed policies; legacy UUID-keyed
+        policies skip it. Expose as a predicate so callers do not need to access
+        the private ``_subject``.
+        """
+        return self._subject.startswith("spiffe://")
+
+    @property
+    def policy_subject(self) -> str:
+        """The agent identity subject this policy was issued for."""
+        return self._subject
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -86,11 +86,15 @@ class TrustRuntime:
                 "updated_at": datetime.now(tz=UTC).isoformat(),
             })
 
-        # 3. Create ToolPolicy — override enforcement_mode to match runtime mode.
-        # Safe: mode is already validated against _valid_modes above, which
-        # matches AgentConstraints.enforcement_mode's Literal["warn","enforce"].
+        # 3. B5: enforce is a FLOOR. A local mode='warn' must not silently downgrade a Console-
+        # (or constraint-) mandated 'enforce'. Take the stronger of the two; record any downgrade
+        # attempt so it is audited (below) rather than honored. mode is already validated above.
+        mandated_mode = self._constraints.enforcement_mode
+        effective_mode = "enforce" if "enforce" in (mandated_mode, mode) else "warn"
+        self._mode_downgrade_attempted: bool = mandated_mode == "enforce" and mode == "warn"
+        self.mode = effective_mode
         constraints_for_policy = self._constraints.model_copy(
-            update={"enforcement_mode": mode}
+            update={"enforcement_mode": effective_mode}
         )
         self._policy = ToolPolicy(constraints_for_policy)
 
@@ -108,7 +112,7 @@ class TrustRuntime:
                         "output-guards": dome_cfg.output_guards,
                     }
                     config.update(dome_cfg.guards)
-                    self._dome = Dome(dome_config=config, enforce=(mode == "enforce"))
+                    self._dome = Dome(dome_config=config, enforce=(effective_mode == "enforce"))
                 except Exception as exc:
                     if mode == "enforce":
                         raise RuntimeError(
@@ -131,6 +135,11 @@ class TrustRuntime:
 
         # 6. Create audit emitter
         self._audit = AuditEmitter(agent_id=agent_id, sink=audit_sink)
+        if self._mode_downgrade_attempted:
+            logger.warning(
+                "local mode='warn' cannot downgrade a mandated 'enforce'; using enforce"
+            )
+            self._audit.emit_mode_downgrade(requested=mode, effective=effective_mode)
 
         if self._guards_disabled:
             self._audit.emit_guards_disabled(

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -355,11 +355,12 @@ class TrustRuntime:
 
     def check_tool_call(self, tool_name: str, args: dict[str, Any]) -> ToolCallResult:
         """Check whether a tool call is permitted by policy."""
+        attested = self._identity.is_attested()
         result = self._policy.check(
             tool_name,
             args=args,
             spiffe_id=self._identity.spiffe_id,
-            attested=self._identity.is_attested(),
+            attested=attested,
         )
         self._audit.emit_tool_mac(
             tool_name,
@@ -367,6 +368,21 @@ class TrustRuntime:
             identity_verified=result.identity_verified,
             agent_spiffe_id=result.agent_spiffe_id,
         )
+        # A3 binding applies to attested callers only. When an SVID-keyed policy is
+        # evaluated for an unattested caller, emit a distinct audit event so the residual
+        # exposure (an unattested caller hitting an identity-bound policy) is visible — it
+        # is not a deny under the default "warn" unattested_tool_policy. Operators close
+        # this fully by setting unattested_tool_policy="deny" or awaiting the DOME-166
+        # default-flip once attestation is the norm.
+        if (
+            not attested
+            and self._policy._subject.startswith("spiffe://")
+            and result.permitted
+        ):
+            self._audit.emit_svid_keyed_unattested(
+                tool_name,
+                policy_subject=self._policy._subject,
+            )
         return result
 
     # ------------------------------------------------------------------
@@ -381,11 +397,11 @@ class TrustRuntime:
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             mac_result = self.check_tool_call(tool_name, kwargs)
 
-            if not mac_result.permitted and self.mode == "enforce":
+            if not mac_result.permitted and mac_result.enforced:
                 raise PermissionError(
                     f"Tool '{tool_name}' denied: {mac_result.error}"
                 )
-            if not mac_result.permitted and self.mode == "warn":
+            if not mac_result.permitted and not mac_result.enforced:
                 logger.warning(
                     "Tool '%s' would be denied in enforce mode: %s",
                     tool_name,

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -374,14 +374,10 @@ class TrustRuntime:
         # is not a deny under the default "warn" unattested_tool_policy. Operators close
         # this fully by setting unattested_tool_policy="deny" or awaiting the DOME-166
         # default-flip once attestation is the norm.
-        if (
-            not attested
-            and self._policy._subject.startswith("spiffe://")
-            and result.permitted
-        ):
+        if not attested and self._policy.is_svid_keyed() and result.permitted:
             self._audit.emit_svid_keyed_unattested(
                 tool_name,
-                policy_subject=self._policy._subject,
+                policy_subject=self._policy.policy_subject,
             )
         return result
 

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -114,7 +114,10 @@ class TrustRuntime:
                     config.update(dome_cfg.guards)
                     self._dome = Dome(dome_config=config, enforce=(effective_mode == "enforce"))
                 except Exception as exc:
-                    if mode == "enforce":
+                    # B5: gate on effective_mode, not the raw local mode — else a Dome-init
+                    # failure under a mandated-enforce-but-local-warn posture would silently
+                    # disable guards (the exact downgrade B5 prevents) instead of raising.
+                    if effective_mode == "enforce":
                         raise RuntimeError(
                             f"Dome initialization failed in enforce mode: {exc}"
                         ) from exc
@@ -237,14 +240,6 @@ class TrustRuntime:
             )
         self._trust_vector = current
         return current
-
-        if self._guards_disabled:
-            self._audit.emit_guards_disabled(
-                error=getattr(self, "_guards_disabled_error", "unknown"),
-            )
-
-        if not self._identity.is_attested():
-            self._audit.emit_identity_unattested()
 
     # ------------------------------------------------------------------
     # Attestation


### PR DESCRIPTION
## Identity-keyed enforcement — A2 + A3 + B5 [DOME-163]

The Evaluate-side of the tamper-evident identity-MAC work. A1 (#242, on
`main`) threaded the attested SPIFFE identity into the MAC decision in
**observe-only** mode. This PR turns that signal into **enforcement**,
behind explicit, non-bricking flags.

**Context:** the founding finding (PR #239 threat model) is that Dome's
in-process controls can today be bypassed *silently* while the agent
stays registered. This PR closes the policy half of that gap: an
operator can now make an unattested or identity-mismatched tool call
**fail closed**, and a local `warn` can no longer silently downgrade a
Console-mandated `enforce`.

### What each commit does

| Commit | Change |
|---|---|
| `a73b67e` **A2** | `AgentConstraints.unattested_tool_policy: "warn" \| "deny"` (default `warn`). `deny` → an unattested agent is denied regardless of tool; `enforcement_mode` decides whether that deny is enforced or only logged. |
| `f9c95ab` **A3** | An **attested** agent must match an SVID-keyed policy subject. A mismatch (loaded another identity's constraints with an API token — the priv-esc the threat model flags) fails closed. Legacy UUID-keyed subjects skip the check (non-bricking). |
| `e0ef99a` **B5** | Enforce is a **floor**. `effective_mode = stronger(mandated, local)`; a local `warn` cannot downgrade a mandated `enforce`. The downgrade attempt is audited (`emit_mode_downgrade`), not honored. |
| `6165b18` **fix** | Closes the 2-lens review's critical + important findings (below) + dead-code removal (DOME-165). |

### Review findings already addressed (self-review, 2-lens + silent-failure pass)

- **Critical (fixed):** the Dome-init exception handler gated on the raw
  local `mode` instead of `effective_mode` — a Dome-init failure under
  mandated-enforce + local-warn would silently disable content guards
  instead of raising. Now gates on `effective_mode`; regression test
  `test_dome_init_failure_under_mandated_enforce_raises`.
- **Important (documented + tested, default-flip deferred):** an
  SVID-keyed policy with an *unattested* caller under the default `warn`
  permits the call (A3 binds only attested callers). Full fail-closed
  (SVID-keyed ⟹ require attestation) was **rejected** — it bricks
  existing unattested-but-SVID-shaped flows (travel-agent,
  `test_policy.py`), the same reason the flag defaults to `warn`. The
  secure config already closes it: `unattested_tool_policy="deny"`
  denies regardless of subject (A2). Documented in `AgentConstraints`;
  both behaviors tested. **Follow-up:** flip the default to `deny` once
  attestation is the norm.

## Disclosure table

| Component | Status | Confirming evidence | Disconfirming check |
|---|---|---|---|
| A2 unattested deny | Real | `policy.py:78` gate; `test_identity_mac_a2.py` (5 tests) | Default `warn` test asserts the normal tool check still runs |
| A3 SVID binding | Real | `policy.py:91` gate; `test_identity_mac_a3.py` (6 tests) | Legacy UUID-keyed test asserts the binding check is skipped |
| B5 enforce-floor | Real | `runtime.py:93` `effective_mode`; `test_identity_mac_b5.py` (7 tests) | `test_no_downgrade_event_when_not_downgrading` asserts no false-positive audit |
| Dome-init fail-closed | Real | `runtime.py:120` gates on `effective_mode`; B5 raise test | Test would DID-NOT-RAISE against the pre-fix `mode` gate |

## 5 review questions

1. **Do tests prove substance?** Yes — permit-path AND deny-path tests
   pin both directions of every gate. The B5 raise test would fail
   against the pre-fix code (raw `mode`), so it is a genuine regression
   guard, not shape-only.
2. **Is zero-result success a bug here?** N/A — this is permit/deny
   logic, not a data pipeline. Each test asserts a concrete
   permitted/error outcome.
3. **Do names lie?** `unattested_tool_policy`, `effective_mode`,
   `emit_mode_downgrade` all match behavior; verified by reading the
   gates, not the identifiers.
4. **External service unreachable?** No new external calls. SPIRE/Console
   wiring is unchanged (A1 + the live-cluster pass own that).
5. **Could a customer be misled?** The one place a default config is
   weaker than an operator might expect (SVID-keyed + unattested + warn)
   is documented at the field and tested; the secure config is one flag
   away. Not silent.

## Silent-failure grep (added trust/ lines)

`except / pass / return None / return [] / continue / # noqa / # type: ignore` → **no hits.**

## Tests

- 149 trust-core (`vijil_dome/tests/trust/`, +2 from this fix) — green
- 60 adapter-MAC (`vijil_dome/tests/trust/adapters/`) — green
- `ruff check` clean; `mypy` clean (17 source files)

## Not in this PR (tracked)

- A4 model-MAC + A5 SVID-glob — depend on the B6 policy-schema fields (#244); land as their own PR.
- B2 loud-fail — after B1 (#247) merges.
- Console-side A8/A9/A10/B4 (incl. missing-agent alert) — next-week fast-follow.
- Pre-existing minors (not regressions from this diff): `_verify_tool_identity` exception breadth; `_guards_disabled_error` defensive getattr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
