### PR TITLE
feat(dome): fetch constraints by attested SVID, not developer-supplied agent_id [DOME-173]

### DIFF
--- a/vijil_dome/tests/trust/test_console_constraints.py
+++ b/vijil_dome/tests/trust/test_console_constraints.py
@@ -230,6 +230,16 @@ class TestTrustRuntimeFetchesBySpiffeId:
 
         client._http.get.assert_called_once_with("/agents/dev-name/constraints")
 
+    def test_fallback_percent_encodes_agent_id_path_segment(self):
+        """A developer-supplied agent_id with path metacharacters is percent-encoded so it
+        cannot change the effective request path (e.g. add a segment via '/')."""
+        client = MagicMock()
+        client._http.get.return_value = _console_constraints_response()
+        client._http._token = "test-api-key"
+        TrustRuntime(client=client, agent_id="a/b?x")
+
+        client._http.get.assert_called_once_with("/agents/a%2Fb%3Fx/constraints")
+
     def test_attested_without_spiffe_id_falls_back_to_agent_id(self):
         """Defensive: is_attested True but no SVID → fall back rather than fetch an empty SVID."""
         client = self._tokenless_client()

--- a/vijil_dome/tests/trust/test_console_constraints.py
+++ b/vijil_dome/tests/trust/test_console_constraints.py
@@ -11,7 +11,8 @@ realistic test data.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+from urllib.parse import quote
 
 from vijil_dome.trust.constraints import AgentConstraints
 from vijil_dome.trust.runtime import TrustRuntime
@@ -173,3 +174,77 @@ class TestTrustRuntimeWithConsoleConstraints:
         assert runtime._constraints.agent_id == "dev-agent"
         assert runtime._constraints.dome_config.input_guards == []
         assert runtime._constraints.enforcement_mode == "warn"
+
+
+class TestTrustRuntimeFetchesBySpiffeId:
+    """A10 (DOME-173): an ATTESTED runtime fetches constraints by its SVID, never by
+    the developer-supplied agent_id string — closing the spoof where a developer picks
+    which constraints apply by naming a different agent_id.
+
+    Activation reflects the real CON-525 path: the pure-mTLS Console client carries no
+    API-key token, so identity resolution (runtime step 1) constructs an
+    ``AgentIdentity(spire_socket=...)`` and attests via SPIRE. These tests patch that
+    constructor (no real SPIRE socket in unit tests) and use a token-LESS client so the
+    SPIRE path is taken for real — not the always-unattested ``from_api_key`` factory."""
+
+    _SVID = "spiffe://vijil.ai/org/7b3c/agent/2f1a"
+
+    @staticmethod
+    def _tokenless_client() -> MagicMock:
+        """A pure-mTLS client: present, but with no API-key token (CON-525 shape)."""
+        client = MagicMock()
+        client._http.get.return_value = _console_constraints_response()
+        client._http._token = None
+        return client
+
+    @staticmethod
+    def _attested_identity(spiffe_id: str | None) -> MagicMock:
+        identity = MagicMock()
+        identity.is_attested.return_value = True
+        identity.spiffe_id = spiffe_id
+        return identity
+
+    def test_attested_runtime_fetches_by_svid_not_agent_id(self):
+        """Token-less client → SPIRE-attested identity → fetch by SVID, not by agent_id."""
+        client = self._tokenless_client()
+        with patch("vijil_dome.trust.runtime.AgentIdentity") as MockIdentity:
+            # The token-less path constructs AgentIdentity(spire_socket=...); make it attested.
+            MockIdentity.return_value = self._attested_identity(self._SVID)
+            TrustRuntime(client=client, agent_id="developer-supplied-name")
+
+        called_url = client._http.get.call_args.args[0]
+        assert called_url.startswith("/agents/constraints-by-spiffe-id?spiffe_id=")
+        # The developer-supplied agent_id must NOT determine the fetch.
+        assert "developer-supplied-name" not in called_url
+        # The SVID is percent-encoded into the query (it carries ':' and '/').
+        assert quote(self._SVID, safe="") in called_url
+
+    def test_unattested_api_key_runtime_falls_back_to_agent_id(self):
+        """A real token-carrying client → from_api_key → unattested → today's agent_id path.
+
+        No identity patching: this exercises the genuine api-key-is-unattested invariant."""
+        client = MagicMock()
+        client._http.get.return_value = _console_constraints_response()
+        client._http._token = "test-api-key"
+        TrustRuntime(client=client, agent_id="dev-name")
+
+        client._http.get.assert_called_once_with("/agents/dev-name/constraints")
+
+    def test_attested_without_spiffe_id_falls_back_to_agent_id(self):
+        """Defensive: is_attested True but no SVID → fall back rather than fetch an empty SVID."""
+        client = self._tokenless_client()
+        with patch("vijil_dome.trust.runtime.AgentIdentity") as MockIdentity:
+            MockIdentity.return_value = self._attested_identity(None)
+            TrustRuntime(client=client, agent_id="dev-name")
+
+        client._http.get.assert_called_once_with("/agents/dev-name/constraints")
+
+    def test_tokenless_client_without_attestation_falls_back_to_agent_id(self, monkeypatch):
+        """The real local-dev path: token-less client but no SPIRE socket and no delegate →
+        the REAL AgentIdentity stays unattested → agent_id fallback. No mock on AgentIdentity,
+        so a future change that silently attested a socketless runtime would fail here."""
+        monkeypatch.delenv("VIJIL_IDENTITY_DELEGATE_URL", raising=False)
+        client = self._tokenless_client()
+        TrustRuntime(client=client, agent_id="dev-name", spire_socket="/nonexistent/spire.sock")
+
+        client._http.get.assert_called_once_with("/agents/dev-name/constraints")

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from vijil_dome.controls.models import Control, EvaluationResult
 from vijil_dome.trust.attestation import AttestationResult, ToolAttestationStatus
@@ -69,7 +70,23 @@ class TrustRuntime:
         elif isinstance(constraints, dict):
             self._constraints = AgentConstraints.model_validate(constraints)
         elif client is not None:
-            raw_constraints = client._http.get(f"/agents/{agent_id}/constraints")
+            # A10: an attested agent fetches by its SVID, not the developer-supplied
+            # agent_id string — so the developer cannot pick which constraints apply by
+            # naming a different agent. The SVID is percent-encoded (it carries ':' and
+            # '/'). This branch activates under the pure-mTLS Console client (CON-525):
+            # that client carries no API-key token, so identity resolution (step 1) takes
+            # the SPIRE path and attests. Transport auth is the mTLS client cert; this code
+            # only chooses WHAT to fetch. DEPLOY GATE: CON-525's Console side must bind the
+            # served constraints to the mTLS-verified cert SVID (not trust this query param
+            # blindly) before this endpoint takes production traffic. An unattested agent
+            # keeps today's by-agent_id behavior so existing key-only flows are not bricked.
+            svid = self._identity.spiffe_id
+            if self._identity.is_attested() and svid:
+                raw_constraints = client._http.get(
+                    f"/agents/constraints-by-spiffe-id?spiffe_id={quote(svid, safe='')}"
+                )
+            else:
+                raw_constraints = client._http.get(f"/agents/{agent_id}/constraints")
             self._constraints = AgentConstraints.model_validate(raw_constraints)
         else:
             # Minimal default: no guards, no tool restrictions, warn mode

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -86,7 +86,11 @@ class TrustRuntime:
                     f"/agents/constraints-by-spiffe-id?spiffe_id={quote(svid, safe='')}"
                 )
             else:
-                raw_constraints = client._http.get(f"/agents/{agent_id}/constraints")
+                # Percent-encode the developer-supplied agent_id too: a '/', '?', or '#'
+                # would otherwise change the effective request path (Copilot review).
+                raw_constraints = client._http.get(
+                    f"/agents/{quote(agent_id, safe='')}/constraints"
+                )
             self._constraints = AgentConstraints.model_validate(raw_constraints)
         else:
             # Minimal default: no guards, no tool restrictions, warn mode


### PR DESCRIPTION
## Summary

A10 of the tamper-evident identity-MAC sprint (DOME-163). When `TrustRuntime`'s identity is SPIFFE-attested, it fetches constraints by the **attested SVID** via the A9 endpoint (`GET /agents/constraints-by-spiffe-id`) instead of the developer-supplied `agent_id` string — closing the spoof where a developer picks which constraints apply by naming a different agent. Unattested agents keep today's by-`agent_id` behavior so existing key-only flows aren't bricked.

One small branch in `runtime.py:71` + 4 tests. No transport-auth code: the mTLS client cert is the credential (CON-525); this only chooses *what* to fetch.

## Activation (founder-confirmed)

The CON-525 Console client is **pure mTLS, token-less**. So identity resolution (runtime step 1) sees no API key, takes the `AgentIdentity(spire_socket=...)` path, and attests via SPIRE — the SVID branch then fires. (A token-carrying client is api-key-backed → unattested by design → agent_id fallback.)

## Review (two-lens)

- **Adversarial** caught that the branch would be *dormant* under a token-carrying client. Resolved by the pure-mTLS confirmation; tests were rewritten to exercise the **real** path (token-less client → SPIRE constructor), not the always-unattested `from_api_key` factory.
- **Parsimony / test-honesty** flagged a missing local-dev coverage case → added a test for the real socketless path (token-less, no SPIRE, no delegate → unattested → fallback).

## ⚠️ Deploy gate (documented in-code)

CON-525's **Console side must bind the served constraints to the mTLS-verified cert SVID** — not trust the `?spiffe_id=` query param blindly — before this endpoint takes production traffic. Until then the endpoint must not be enabled in prod.

## Depends on

- **vijil-console #956 (A9)** — the `/agents/constraints-by-spiffe-id` endpoint this calls. Runtime dependency only (different repo); this PR has no code dependency on it.

## Follow-up (pre-existing, minor)

The unattested fallback interpolates `agent_id` into the URL path unencoded. Not an escalation (the caller is already self-authenticated), but worth a small hardening ticket.

## Test plan

- [x] `poetry run pytest vijil_dome/tests/trust/ --ignore=.../adapters` → 173 pass (4 new)
- [x] `make lint` (ruff + mypy, types-requests installed as CI does) clean
- [ ] Live: SPIRE-attested workload + CON-525 mTLS client → boot fetches constraints by SVID (cluster-gated; rides CON-525's live pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)