### PR TITLE
feat(dome): enforce mode defaults content guards to fail_closed [DOME-167]

### DIFF
--- a/vijil_dome/Dome.py
+++ b/vijil_dome/Dome.py
@@ -200,7 +200,7 @@ class Dome:
                 )
             else:
                 raise ValueError(
-                    f"Dome recieved an invalid type ({type(dome_config)}) for configuration. Please use a dictionary, a path to a .toml file, or a DomeConfig object to initialize Dome."
+                    f"Dome received an invalid type ({type(dome_config)}) for configuration. Please use a dictionary, a path to a .toml file, or a DomeConfig object to initialize Dome."
                 )
         else:
             self._init_from_dome_config(

--- a/vijil_dome/Dome.py
+++ b/vijil_dome/Dome.py
@@ -14,7 +14,13 @@
 #
 # vijil and vijil-dome are trademarks owned by Vijil Inc.
 
-from vijil_dome.guardrails import Guardrail, GuardrailConfig, BatchGuardrailResult
+from vijil_dome.guardrails import (
+    Guardrail,
+    GuardrailConfig,
+    BatchGuardrailResult,
+    DEFAULT_ON_ERROR,
+    OnError,
+)
 from vijil_dome.guardrails.config_parser import (
     convert_dict_to_guardrails,
     convert_toml_to_guardrails,
@@ -70,10 +76,12 @@ class DomeConfig(GuardrailConfig):
         return self.config_id
 
 
-def create_dome_config(config: Union[Dict, str]) -> DomeConfig:
+def create_dome_config(
+    config: Union[Dict, str], default_on_error: OnError = DEFAULT_ON_ERROR
+) -> DomeConfig:
     if isinstance(config, str):
         input_guardrail, output_guardrail, agent_id, team_id, user_id = (
-            convert_toml_to_guardrails(config)
+            convert_toml_to_guardrails(config, default_on_error)
         )
         config_object = DomeConfig(
             input_guardrail,
@@ -85,7 +93,7 @@ def create_dome_config(config: Union[Dict, str]) -> DomeConfig:
         return config_object
     elif isinstance(config, dict):
         input_guardrail, output_guardrail, agent_id, team_id, user_id = (
-            convert_dict_to_guardrails(config)
+            convert_dict_to_guardrails(config, default_on_error)
         )
         config_id = config.get("id")
         config_object = DomeConfig(
@@ -179,17 +187,25 @@ class Dome:
         self._s3_config_dict = None  # type: Optional[Dict]
         self._s3_aws_kwargs = None  # type: Optional[Dict]
         self._s3_cache_dir = None  # type: Optional[str]
+        # DOME-167: in enforce mode, content guards default to fail_closed so an unreachable
+        # detector BLOCKS rather than silently passing; an explicit on-error in the config still
+        # wins. A pre-built DomeConfig is taken as-is — its guards already carry their on-error.
+        default_on_error: OnError = "fail_closed" if enforce else DEFAULT_ON_ERROR
         if dome_config is not None:
             if isinstance(dome_config, DomeConfig):
                 self._init_from_dome_config(dome_config)
             elif isinstance(dome_config, str) or isinstance(dome_config, dict):
-                self._init_from_dome_config(create_dome_config(dome_config))
+                self._init_from_dome_config(
+                    create_dome_config(dome_config, default_on_error)
+                )
             else:
                 raise ValueError(
                     f"Dome recieved an invalid type ({type(dome_config)}) for configuration. Please use a dictionary, a path to a .toml file, or a DomeConfig object to initialize Dome."
                 )
         else:
-            self._init_from_dome_config(create_dome_config(get_default_config()))
+            self._init_from_dome_config(
+                create_dome_config(get_default_config(), default_on_error)
+            )
 
     @staticmethod
     def create_from_config(

--- a/vijil_dome/guardrails/config_parser.py
+++ b/vijil_dome/guardrails/config_parser.py
@@ -311,7 +311,11 @@ def create_guard(
 
 
 # Create a guardrail object from a config dict
-def create_guardrail(guardrail_location: str, config_dict: dict) -> Guardrail:
+def create_guardrail(
+    guardrail_location: str,
+    config_dict: dict,
+    default_on_error: OnError = DEFAULT_ON_ERROR,
+) -> Guardrail:
     if guardrail_location not in ["input", "output"]:
         raise ValueError(f"Invalid location for guardrail: {guardrail_location}")
 
@@ -328,12 +332,15 @@ def create_guardrail(guardrail_location: str, config_dict: dict) -> Guardrail:
 
     # Resolve the guardrail-level on-error first so it can be propagated as
     # the default to each child guard (a per-guard on-error still wins).
+    # When the config omits on-error, fall back to default_on_error — enforce mode
+    # passes fail_closed here (DOME-167) so an unset guardrail blocks rather than
+    # silently passing on a detector error; an explicit config value still wins.
     if on_error_key in config_dict:
         on_error = _coerce_on_error(
             config_dict[on_error_key], f"{guardrail_location} guardrail"
         )
     else:
-        on_error = DEFAULT_ON_ERROR
+        on_error = default_on_error
 
     if guard_level in config_dict:  # maybe worth raising a warning if missing?
         guard_list = config_dict[guard_level]
@@ -391,7 +398,9 @@ def extract_field_from_toml(field_level, field_name, default_value, toml_dict):
 
 
 # Convert a toml config file into a guardrail dict
-def convert_toml_to_guardrail_dict(path_to_toml: str):
+def convert_toml_to_guardrail_dict(
+    path_to_toml: str, default_on_error: OnError = DEFAULT_ON_ERROR
+):
     with open(path_to_toml, "r") as file:
         toml_config_dict = toml.load(file)
 
@@ -424,7 +433,7 @@ def convert_toml_to_guardrail_dict(path_to_toml: str):
         "input", "blocked-message", None, toml_config_dict
     )
     raw_config_dict["input-on-error"] = extract_field_from_toml(
-        "input", "on-error", DEFAULT_ON_ERROR, toml_config_dict
+        "input", "on-error", default_on_error, toml_config_dict
     )
     raw_config_dict["output-guards"] = extract_field_from_toml(
         "output", "guards", [], toml_config_dict
@@ -439,7 +448,7 @@ def convert_toml_to_guardrail_dict(path_to_toml: str):
         "output", "blocked-message", None, toml_config_dict
     )
     raw_config_dict["output-on-error"] = extract_field_from_toml(
-        "output", "on-error", DEFAULT_ON_ERROR, toml_config_dict
+        "output", "on-error", default_on_error, toml_config_dict
     )
 
     for groupname in raw_config_dict["input-guards"]:
@@ -453,9 +462,10 @@ def convert_toml_to_guardrail_dict(path_to_toml: str):
 # Convert a dictionary into the corresponding guardrails
 def convert_dict_to_guardrails(
     config_dict: dict,
+    default_on_error: OnError = DEFAULT_ON_ERROR,
 ) -> Tuple[Guardrail, Guardrail, Optional[str], Optional[str], Optional[str]]:
-    input_guardrail = create_guardrail("input", config_dict)
-    output_guardrail = create_guardrail("output", config_dict)
+    input_guardrail = create_guardrail("input", config_dict, default_on_error)
+    output_guardrail = create_guardrail("output", config_dict, default_on_error)
     team_id = config_dict.get("team_id", None)
     user_id = config_dict.get("user_id", None)
     agent_id = config_dict.get("agent_id") or config_dict.get("agent_config_id")
@@ -465,6 +475,7 @@ def convert_dict_to_guardrails(
 # convert a toml file into its corresponding guardrails
 def convert_toml_to_guardrails(
     path_to_toml: str,
+    default_on_error: OnError = DEFAULT_ON_ERROR,
 ) -> Tuple[Guardrail, Guardrail, Optional[str], Optional[str], Optional[str]]:
-    config_dict = convert_toml_to_guardrail_dict(path_to_toml)
-    return convert_dict_to_guardrails(config_dict)
+    config_dict = convert_toml_to_guardrail_dict(path_to_toml, default_on_error)
+    return convert_dict_to_guardrails(config_dict, default_on_error)

--- a/vijil_dome/tests/test_dome_obj.py
+++ b/vijil_dome/tests/test_dome_obj.py
@@ -246,3 +246,67 @@ def test_toml_config_generic_policy_guard(tmp_path):
     assert detector.reasoning_effort == "medium"
 
     assert dome.agent_id is None
+
+
+# ---------------------------------------------------------------------------
+# DOME-167: enforce mode auto-selects fail_closed for content guards.
+# B1 (#247) shipped the on_error=fail_closed lever; enforce mode flips it on by
+# default, so a detector that is unreachable BLOCKS rather than silently passing.
+# An explicit per-guardrail / per-guard on-error still wins (operator escape).
+# encoding-heuristics is a pure-local detector (no model weights / network): we
+# build the guardrail and inspect on_error, never run a scan.
+# ---------------------------------------------------------------------------
+
+_ENFORCE_HEURISTIC_CONFIG = {
+    "input-guards": ["in-guard"],
+    "output-guards": ["out-guard"],
+    "in-guard": {"type": "security", "methods": ["encoding-heuristics"]},
+    "out-guard": {"type": "security", "methods": ["encoding-heuristics"]},
+}
+
+
+def test_dome_enforce_defaults_guards_to_fail_closed() -> None:
+    dome = Dome(dome_config=_ENFORCE_HEURISTIC_CONFIG, enforce=True)
+
+    assert dome.input_guardrail.on_error == "fail_closed"
+    assert dome.output_guardrail.on_error == "fail_closed"
+    assert all(g.on_error == "fail_closed" for g in dome.input_guardrail.guard_list)
+
+
+def test_dome_shadow_mode_keeps_fail_open_default() -> None:
+    # enforce=False (shadow mode) must NOT flip the back-compatible default.
+    dome = Dome(dome_config=_ENFORCE_HEURISTIC_CONFIG, enforce=False)
+
+    assert dome.input_guardrail.on_error == "fail_open"
+    assert dome.output_guardrail.on_error == "fail_open"
+
+
+def test_dome_explicit_on_error_wins_over_enforce_default() -> None:
+    # An operator who explicitly sets fail_open keeps it even under enforce — the
+    # escape hatch for a flaky detector. Explicit config beats the enforce default.
+    config = {
+        "input-guards": ["in-guard"],
+        "input-on-error": "fail_open",
+        "in-guard": {"type": "security", "methods": ["encoding-heuristics"]},
+    }
+    dome = Dome(dome_config=config, enforce=True)
+
+    assert dome.input_guardrail.on_error == "fail_open"
+    assert all(g.on_error == "fail_open" for g in dome.input_guardrail.guard_list)
+
+
+def test_dome_enforce_defaults_toml_guards_to_fail_closed(tmp_path: Path) -> None:
+    # The toml loader pre-fills on-error, so this path is the subtle one: enforce must still
+    # flip an OMITTED on-error to fail_closed, and an EXPLICIT toml on-error must still win.
+    guard_block = '\n[in-guard]\ntype = "security"\nmethods = ["encoding-heuristics"]\n'
+
+    omitted = tmp_path / "omitted.toml"
+    omitted.write_text('[guardrail]\ninput-guards = ["in-guard"]\n' + guard_block)
+    assert Dome(dome_config=str(omitted), enforce=True).input_guardrail.on_error == "fail_closed"
+    assert Dome(dome_config=str(omitted), enforce=False).input_guardrail.on_error == "fail_open"
+
+    explicit = tmp_path / "explicit.toml"
+    explicit.write_text(
+        '[guardrail]\ninput-guards = ["in-guard"]\ninput-on-error = "fail_open"\n' + guard_block
+    )
+    assert Dome(dome_config=str(explicit), enforce=True).input_guardrail.on_error == "fail_open"

--- a/vijil_dome/tests/test_guardrail_infrastructure.py
+++ b/vijil_dome/tests/test_guardrail_infrastructure.py
@@ -574,6 +574,30 @@ def test_config_parser_wires_on_error_to_guard_and_guardrail() -> None:
     assert all(g.on_error == "fail_closed" for g in guardrail.guard_list)
 
 
+def test_create_guardrail_default_on_error_applies_when_config_omits_it() -> None:
+    """DOME-167: enforce mode passes default_on_error="fail_closed"; it applies only when the
+    config omits on-error. An explicit config on-error still wins, and with no default the
+    back-compatible fail_open is preserved."""
+    from vijil_dome.guardrails.config_parser import create_guardrail
+
+    config = {
+        "input-guards": ["my-guard"],
+        "my-guard": {"type": "security", "methods": ["encoding-heuristics"]},
+    }
+
+    # enforce mode supplies fail_closed → applies, propagates to child guards
+    enforced = create_guardrail("input", config, default_on_error="fail_closed")
+    assert enforced.on_error == "fail_closed"
+    assert all(g.on_error == "fail_closed" for g in enforced.guard_list)
+
+    # back-compat: no default supplied → fail_open
+    assert create_guardrail("input", config).on_error == "fail_open"
+
+    # explicit config on-error beats the enforce default
+    explicit = {**config, "input-on-error": "fail_open"}
+    assert create_guardrail("input", explicit, default_on_error="fail_closed").on_error == "fail_open"
+
+
 def test_config_parser_invalid_on_error_raises() -> None:
     """A typo in on-error must fail loud, not silently default to fail_open."""
     from vijil_dome.guardrails.config_parser import create_guardrail


### PR DESCRIPTION
## What

Make **enforce mode auto-select `fail_closed`** as the default `on_error` for content guards (DOME-167, child of DOME-163). B1 (#247) shipped the `on_error=fail_closed` lever; this flips it on by default in enforce mode, closing the founding-finding fail-open: **a detector that is unreachable now BLOCKS rather than silently passing.**

## ⚠️ Behavior change

A **running enforce-mode agent now blocks on detector-unreachable** (previously it failed open and passed). This is the intended tamper-evidence. **Escape hatch:** set `input-on-error: fail_open` / `output-on-error: fail_open` (or per-guard) in the config — an explicit `on-error` still wins.

## How

A `default_on_error` param (= `fail_closed` when `enforce=True`, else `fail_open`) threads from `Dome.__init__` → `create_dome_config` → `convert_dict_to_guardrails` / `convert_toml_to_guardrails` (+ `convert_toml_to_guardrail_dict`) → `create_guardrail`'s fallback (used only when the config omits `on-error`). Precedence is unchanged: **explicit per-guard > explicit guardrail-level > the enforce default**.

- The identity-MAC runtime builds a **dict** config (`trust/runtime.py:136`) → hits the threaded path → enforce-mode agents get `fail_closed`.
- A **pre-built `DomeConfig`** is taken as-is (its guards already carry `on-error`); reached only by example scripts, never `secure_agent`/`TrustRuntime`.
- Shadow mode (`enforce=False`) is unchanged. All new params default to `fail_open`, so non-enforce and direct-API callers are byte-for-byte unaffected.

## Tests + gates

- 5 tests: dict-path (`enforce`→fail_closed), toml-path (omitted→fail_closed, explicit→wins), `create_guardrail` unit (param + back-compat), explicit-wins-under-enforce, shadow-unchanged.
- `make lint` (ruff + mypy, 210 files) green; 175 trust-core + 46 Dome/guardrail tests green.
- Steelman (parsimony + adversarial) + silent-failure-hunter: both **PASS** — no silent-fail-open-under-enforce on any production path.

Follow-up: **B2 (DOME-177)** adds the `detector_unavailable_total` loud metric (the observability half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
