### PR TITLE
test(dome): cover sequential-path fail-closed when a guard raises [DOME-170]

### DIFF
--- a/vijil_dome/tests/test_guardrail_infrastructure.py
+++ b/vijil_dome/tests/test_guardrail_infrastructure.py
@@ -554,6 +554,59 @@ async def test_guardrail_fail_open_default_passes_when_guard_task_raises() -> No
     assert result.flagged is False
 
 
+@pytest.mark.asyncio
+async def test_guardrail_sequential_fail_closed_blocks_when_guard_raises() -> None:
+    """DOME-170: a guard that raises on the SEQUENTIAL guardrail path must fail_closed -> BLOCK,
+    symmetric with the parallel path, naming the crashed guard rather than letting it vanish."""
+
+    class ExplodingGuard(Guard):
+        async def async_scan(self, *args, **kwargs):  # type: ignore[override]
+            raise RuntimeError("guard exploded")
+
+    exploding = ExplodingGuard(
+        guard_name="boom",
+        detector_list=[MockCleanDetector()],
+        run_in_parallel=False,
+    )
+    guardrail = Guardrail(
+        level="input",
+        guard_list=[exploding],
+        run_in_parallel=False,
+        on_error="fail_closed",
+    )
+
+    result = await guardrail.async_scan("test input")
+
+    assert result.flagged is True
+    assert "boom:<guard-task-raised>" in result.errored_methods
+
+
+@pytest.mark.asyncio
+async def test_guardrail_sequential_fail_open_default_passes_when_guard_raises() -> None:
+    """Back-compat on the SEQUENTIAL path: default fail_open still drops a raising guard and
+    passes, but the crash is still recorded in errored_methods (visible, not silent)."""
+
+    class ExplodingGuard(Guard):
+        async def async_scan(self, *args, **kwargs):  # type: ignore[override]
+            raise RuntimeError("guard exploded")
+
+    exploding = ExplodingGuard(
+        guard_name="boom",
+        detector_list=[MockCleanDetector()],
+        run_in_parallel=False,
+    )
+    guardrail = Guardrail(
+        level="input",
+        guard_list=[exploding],
+        run_in_parallel=False,
+    )
+
+    result = await guardrail.async_scan("test input")
+
+    assert result.flagged is False
+    assert "boom:<guard-task-raised>" in result.errored_methods
+
+
 def test_config_parser_wires_on_error_to_guard_and_guardrail() -> None:
     """on_error from the config dict must reach both the Guardrail and its Guards."""
     from vijil_dome.guardrails.config_parser import create_guardrail


### PR DESCRIPTION
## What

DOME-170 (child of DOME-163) asked to symmetrize fail-closed handling when a whole **guard** raises, across the sequential and parallel Guardrail paths.

**The implementation already landed** in `ec36c56` (the #247 B1 commit, which prompted the ticket): the sequential path (`guardrails/__init__.py:703-752`) wraps `await guard.async_scan(...)`, re-raises `CancelledError`, records a raising guard as `<guard-task-raised>` in `errored_methods`, and fail-closed-promotes — symmetric with the parallel path. The ticket is effectively stale on the code side.

**The gap was test coverage:** only the parallel guard-raises case was tested (`run_in_parallel=True`). This PR adds the **sequential** mirrors (`run_in_parallel=False`):
- `fail_closed` → BLOCK + the crashed guard named in `errored_methods`.
- `fail_open` (default) → pass, but the crash is still recorded (visible, not silent).

This locks the previously-untested sequential fail-closed-on-guard-crash so a future refactor can't silently regress it (the same untested-safety-property lesson as DOME-167/B4).

## Scope + gates

Test-only — no source change; mirrors the existing parallel tests; the impl was reviewed in #247. `make lint` (ruff + mypy, 210 files) + the guard-infrastructure suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
