### PR TITLE
feat(dome): enforcement-alive heartbeat — scheduler, real probe, signing seam [DOME-169]

### DIFF
--- a/docs/plans/2026-06-14-dome-169-heartbeat-scheduler-plan.md
+++ b/docs/plans/2026-06-14-dome-169-heartbeat-scheduler-plan.md
@@ -1,0 +1,143 @@
+---
+title: DOME-169 Enforcement-alive heartbeat — scheduler, real probe, signing seam — Implementation Plan
+date: 2026-06-14
+persona: Risk Owner (operator who must detect an agent that goes dark)
+design: docs/trust/2026-06-04-tamper-evident-identity-mac-plan.md
+prfaq: docs/trust/2026-06-04-in-process-control-bypass-threat-model.md
+prd: docs/trust/2026-06-04-in-process-control-bypass-threat-model.md
+linear: https://linear.app/vijil/issue/DOME-169
+branch: ciphr/dome-169-heartbeat-scheduler-signer
+status: Draft
+graphify_snapshot: 98be0bf445f017f87fb5ac46bf29ab5534053728
+---
+
+# DOME-169 Enforcement-alive heartbeat — Implementation Plan
+
+**Goal:** Drive `emit_heartbeat()` on a self-monitoring cadence, report a real detector-reachability signal, and add a signing seam — so a registered agent that goes dark or silently downgrades is detectable in-process, arming B4's liveness reconciler.
+
+**Architecture:** B3 (PR #245) landed the `Heartbeat` event shape and `emit_heartbeat()`; nothing calls it, `detector_reachable` is a proxy, the beacon is unsigned. This plan adds a `BeaconSigner` seam (Domain), a real bounded reachability probe plus a supervised daemon-thread scheduler with an in-process liveness self-check (Application), and forwards an opt-in `heartbeat_interval` through `secure_agent` and all three adapters (Adapter).
+
+**Snapshot note:** `graph.json` was built at `98be0bf`; it lags `main` (`e15b6d4`) by the 167/168/170 merges, none of which touch the heartbeat/identity/adapter symbols below. Every file:line claim was re-verified by direct read against `e15b6d4`.
+
+**Design-divergence flag (vs design B3).** The design (`...mac-plan.md`) specifies the beacon "SVID-signed now." This plan ships the signing *seam* and a real `X509BeaconSigner` exercised with a synthetic key, but the **default is `UnwiredBeaconSigner` (`signed=False`)** because `_svid.private_key`/`_svid.leaf` exist only under live SPIRE attestation (cluster-gated). Wiring the live signer + Console verify is deferred to **DOME-179** (filed). This is a conscious, tracked relaxation of "signed now" to "seam now, live-signed at cluster" — surfaced here, not silent.
+
+## Transitive Infrastructure
+
+| Runtime check | Required infra | Availability |
+|---|---|---|
+| Unit + integration suite (`poetry run pytest vijil_dome/tests/trust/`) | Poetry env; no network; synthetic EC key + injected clock in-test | Local |
+| Signer unit tests | `cryptography` (already a dep, used by `identity.py`) | Local |
+
+No live SPIRE socket, Console, or cluster is required — the live signer is out of scope (DOME-179).
+
+## Dependency Graph
+
+```
+Train 1 (Domain):                  1.1
+Train 2 (Application, after T1):    2.1 -> 2.2
+Train 3 (Adapter+Test, after T2):  3.1 -> 3.2
+```
+
+**Layer-order note:** Train 3's Adapter task (3.1) forwards a param into the `TrustRuntime` API that Train 2's Application task (2.2) introduces; the param cannot be forwarded before it exists, so Application precedes Adapter here (dependency-justified deviation from the canonical Adapter→Application order). Trains are commit-groups within one PR (DOME-169); the `UnwiredBeaconSigner`/unset-interval defaults preserve current behavior, so each train is independently revertable.
+
+## Train 1: Signing seam (Domain)
+
+### Task 1.1: BeaconSigner Protocol + signers + Heartbeat.signature
+
+**Layer:** Domain
+**Files:** Create `vijil_dome/trust/signing.py`; Modify `vijil_dome/trust/audit.py` (`Heartbeat` + `emit_heartbeat`); Test `vijil_dome/tests/trust/test_beacon_signing.py`
+**Linear Issue:** DOME-169
+**Commit:** `feat(dome): add BeaconSigner seam + signed heartbeat envelope [DOME-169]`
+**Target size:** 280 lines
+
+Define `BeaconSignature` (Pydantic: `alg`, `signature` b64, `cert_chain` PEM list, `signed_subject` SPIFFE id) and `BeaconSigner` Protocol `sign(beacon: Heartbeat) -> BeaconSignature | None`. `UnwiredBeaconSigner.sign` returns `None` (beacon ships `signed=False`) — the honest default for unattested/api-key agents. `X509BeaconSigner.sign` signs canonical JSON of the beacon's identity-bearing fields with the SVID private key (ECDSA/RSA by key type) and attaches the leaf cert. Add `signature: BeaconSignature | None = None` to `Heartbeat`; thread through `AuditEmitter.emit_heartbeat`. Tests: synthetic `ec.generate_private_key` + self-signed cert → sign/verify round-trip; unwired → `None`; canonical-JSON determinism.
+
+**Context-graph audit:**
+- `trust_audit_heartbeat` @ `audit.py:L27` confirms `Heartbeat` location ✓ (direct-read verified, e15b6d4)
+- `trust_audit_auditemitter_emit_heartbeat` @ `audit.py:L118` confirms emit signature ✓
+- `trust_identity_agentidentity` @ `identity.py:L34`; `_svid.private_key`/`.leaf` used by `mtls_context` (L285-286) ✓
+
+## Train 2: Probe + scheduler (Application)
+
+### Task 2.1: Real, bounded detector_reachable probe
+
+**Layer:** Application
+**Files:** Modify `vijil_dome/trust/runtime.py` (`emit_heartbeat` + `_probe_detector_reachable`); Test `vijil_dome/tests/trust/test_heartbeat_probe.py`
+**Linear Issue:** DOME-169
+**Commit:** `feat(dome): bounded detector-reachability probe for the heartbeat [DOME-169]`
+**Target size:** 170 lines
+
+Replace the `detector_reachable = self._dome is not None and not self._guards_disabled` proxy (runtime.py:679) with `_probe_detector_reachable()`: `False` when `_dome is None` (not configured) or `_guards_disabled`; else run a fixed benign canned string through `self._dome.guard_input` directly (bypasses the audit-emitting runtime wrapper at runtime.py:337) inside a try — success ⇒ `True`, any exception ⇒ `False` (never propagates). **Cost bound:** cache the result with a TTL (≥ the heartbeat interval) so the real detectors (HF/LLM/OpenAI-moderation can be in the config) run at most once per cadence, not per call; document the per-probe inference cost in the docstring. `guards_constructed` stays `_dome is not None and not _guards_disabled` — the two fields now mean different things. Tests: four states (none / disabled / probe-raises / probe-succeeds) with a stub Dome; TTL cache hit.
+
+**Context-graph audit:**
+- `trust_runtime_trustruntime_emit_heartbeat` @ `runtime.py:L660`; proxy at L679; `runtime.guard_input`→`self._dome.guard_input`+`emit_guard` at L337 ✓ (direct-read verified)
+- `vijil_dome_dome_dome_guard_input` @ `Dome.py:L354` confirms `Dome.guard_input` (no audit emit of its own) ✓
+
+### Task 2.2: Supervised scheduler + in-process liveness self-check
+
+**Layer:** Application
+**Files:** Modify `vijil_dome/trust/runtime.py` (`__init__` params, `start_heartbeat`/`stop_heartbeat`/`heartbeat_health`, watchdog); Test `vijil_dome/tests/trust/test_heartbeat_scheduler.py`
+**Linear Issue:** DOME-169
+**Commit:** `feat(dome): supervised heartbeat scheduler with in-process liveness check [DOME-169]`
+**Target size:** 250 lines
+
+Add `heartbeat_interval: float | None = None`, `beacon_signer: BeaconSigner | None = None` (default `UnwiredBeaconSigner`) to `__init__`. `start_heartbeat()` spawns a `threading.Thread(daemon=True)` looping `emit_heartbeat(); _clock.wait(interval)`; records `_last_emit_at`; per-iteration `try` so one failure never kills the loop, and on an escaped error it loudly logs + sets a `_thread_failed` flag. **In-process liveness (the design's "dead loop is loud"):** `heartbeat_health()` returns `{alive, last_emit_age_s, thread_failed}` and is `alive=False` when `last_emit_age_s > 2×interval` — a host or B4 can poll it WITHOUT depending on the deferred Console sweep. `stop_heartbeat()` signals via `threading.Event` and `join(timeout=...)` (bounded, no hang); idempotent. If `heartbeat_interval` is set, `__init__` auto-starts (documented construction side-effect; daemon, never blocks exit; one thread per runtime instance — documented). Inject a clock seam so tests are deterministic (no real sleeps). `emit_heartbeat` attaches `beacon_signer.sign(...)`. Tests: clock-driven ≥2 beacons; bounded idempotent stop; injected per-iteration error keeps loop alive + `heartbeat_health().alive` stays true; simulated dead thread ⇒ `alive=False`.
+
+**Context-graph audit:**
+- `trust_runtime_trustruntime` @ `runtime.py:L33` confirms `__init__` extension point; no thread/timer exists in `trust/` (net-new) ✓ (direct-read verified)
+
+## Train 3: Adapter wiring + integration (Adapter, Test)
+
+### Task 3.1: Forward heartbeat_interval through secure_agent + all three adapters
+
+**Layer:** Adapter
+**Files:** Modify `vijil_dome/trust/adapters/auto.py`, `langgraph.py`, `adk.py`, `strands.py`; Test `vijil_dome/tests/trust/adapters/test_secure_agent_heartbeat.py`
+**Linear Issue:** DOME-169
+**Commit:** `feat(dome): wire heartbeat_interval through secure_agent and adapters [DOME-169]`
+**Target size:** 150 lines
+
+Add `heartbeat_interval`/`beacon_signer` to `secure_agent` (auto.py:31) and thread them into **all three** adapters' `TrustRuntime(...)` constructions — `langgraph.py:190`, `adk.py:71`, `strands.py:141`. **Correction:** langgraph does NOT get this free; its `**compile_kwargs` route to `graph.compile()` (langgraph.py:200), never to `TrustRuntime`, so all three need explicit threading. Tests assert each framework's runtime has a live scheduler after `secure_agent(..., heartbeat_interval=...)`.
+
+**Context-graph audit:**
+- `adapters_auto_secure_agent` @ `auto.py:L31`; `secure_graph` `TrustRuntime(...)` at langgraph.py:190 takes fixed args only (`**compile_kwargs`→`graph.compile()` L200); `adk.py:71`, `strands.py:141` likewise ✓ (direct-read verified)
+
+### Task 3.2: End-to-end heartbeat integration test
+
+**Layer:** Test
+**Files:** Test `vijil_dome/tests/trust/test_heartbeat_e2e.py`
+**Linear Issue:** DOME-169
+**Commit:** `test(dome): end-to-end heartbeat cadence, probe, liveness, signing [DOME-169]`
+**Target size:** 160 lines
+
+Capture beacons via an audit sink. With a stub Dome + synthetic-key `X509BeaconSigner` + injected clock: assert beacons emit on cadence, carry a signature that verifies, `detector_reachable` flips with stubbed backend health, `heartbeat_health().alive` reflects a stalled loop, and the unwired default ships `signed=False`. Drives a real `TrustRuntime`.
+
+**Context-graph audit:**
+- `vijil_dome_tests_trust_test_heartbeat_b3_py` confirms canonical trust test dir `vijil_dome/tests/trust/` ✓
+
+## Deferred / Out of scope
+
+| Deferred item | Why | Tracking |
+|---|---|---|
+| Live `X509BeaconSigner` wired to a real SPIRE SVID (signs every beacon on a real install) | `_svid.private_key` requires live SPIRE attestation (cluster) | **DOME-179** |
+| Console-side beacon signature verification + bind to B4 liveness record | Needs Console + cluster; pairs with B4 (DOME-174) and CON-525 mTLS swap | **DOME-179** |
+| TEE remote-attestation quote (replaces SVID-sign) | Roadmap (Phala × Vijil) | design doc roadmap |
+
+## Pre-Commit Checklist
+
+- [ ] `poetry run pytest vijil_dome/tests/trust/` green (2 output-detection tests fail locally without `OPENAI_API_KEY` — pre-existing, pass in CI)
+- [ ] `make lint` clean (ruff + mypy via mypy.ini, src AND tests)
+- [ ] No silent fail-open: probe exceptions ⇒ `detector_reachable=False` (never propagate); a dead scheduler ⇒ `heartbeat_health().alive=False` in-process (not reliant on deferred B4)
+- [ ] `stop_heartbeat` join is bounded; scheduler tests use an injected clock (no real-sleep flake)
+- [ ] `vijil-steelman` + silent-failure-hunter PASS on the combined diff
+- [ ] PR body states the DOME-179 deferred boundary + the design-B3 divergence
+
+## Sizing Summary
+
+| Task | Layer | Lines |
+|---|---|---|
+| 1.1 BeaconSigner seam + signature | Domain | 280 |
+| 2.1 Bounded reachability probe | Application | 170 |
+| 2.2 Scheduler + liveness self-check | Application | 250 |
+| 3.1 secure_agent + 3-adapter wiring | Adapter | 150 |
+| 3.2 E2E integration test | Test | 160 |
+| **Total** | | **1010** |

--- a/vijil_dome/tests/trust/adapters/test_secure_agent_heartbeat.py
+++ b/vijil_dome/tests/trust/adapters/test_secure_agent_heartbeat.py
@@ -1,0 +1,112 @@
+"""secure_agent and all three adapters forward heartbeat params (DOME-169 Task 3.1).
+
+The adapters' only job here is to thread ``heartbeat_interval`` and
+``beacon_signer`` into ``TrustRuntime`` — the scheduler behaviour itself is
+covered by the runtime tests. A capturing fake runtime records the constructor
+kwargs and aborts early, so these tests verify the forwarding without the
+framework graph/callback machinery. The corrected scope includes LangGraph,
+which does NOT get the params for free (its ``**compile_kwargs`` route to
+``graph.compile()``, not to ``TrustRuntime``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vijil_dome.trust.signing import UnwiredBeaconSigner
+
+_SIGNER = UnwiredBeaconSigner()
+_INTERVAL = 0.5
+
+
+class _Captured(Exception):
+    """Raised by the fake runtime to capture ctor kwargs and abort early."""
+
+
+class _CapturingRuntime:
+    last_kwargs: dict[str, Any] = {}
+
+    def __init__(self, **kwargs: Any) -> None:
+        _CapturingRuntime.last_kwargs = dict(kwargs)
+        raise _Captured
+
+
+def _assert_forwarded() -> None:
+    captured = _CapturingRuntime.last_kwargs
+    assert captured["heartbeat_interval"] == _INTERVAL
+    assert captured["beacon_signer"] is _SIGNER
+
+
+def test_langgraph_secure_graph_forwards(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vijil_dome.trust.adapters import langgraph as lg
+
+    monkeypatch.setattr(lg, "TrustRuntime", _CapturingRuntime)
+    with pytest.raises(_Captured):
+        lg.secure_graph(
+            SimpleNamespace(),
+            agent_id="a",
+            constraints={},
+            heartbeat_interval=_INTERVAL,
+            beacon_signer=_SIGNER,
+        )
+    _assert_forwarded()
+
+
+def test_adk_secure_agent_forwards(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("google.adk")
+    from vijil_dome.trust.adapters import adk
+
+    monkeypatch.setattr(adk, "TrustRuntime", _CapturingRuntime)
+    with pytest.raises(_Captured):
+        adk.secure_agent(
+            SimpleNamespace(),
+            agent_id="a",
+            constraints={},
+            heartbeat_interval=_INTERVAL,
+            beacon_signer=_SIGNER,
+        )
+    _assert_forwarded()
+
+
+def test_strands_secure_agent_forwards(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("strands")
+    from vijil_dome.trust.adapters import strands
+
+    monkeypatch.setattr(strands, "TrustRuntime", _CapturingRuntime)
+    with pytest.raises(_Captured):
+        strands.secure_agent(
+            SimpleNamespace(),
+            agent_id="a",
+            constraints={},
+            heartbeat_interval=_INTERVAL,
+            beacon_signer=_SIGNER,
+        )
+    _assert_forwarded()
+
+
+def test_auto_secure_agent_forwards_to_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vijil_dome.trust.adapters import auto
+
+    captured: dict[str, Any] = {}
+
+    def _fake_secure_graph(graph: Any, **kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "wrapped"
+
+    monkeypatch.setattr(auto, "_detect_framework", lambda agent: "langgraph")
+    monkeypatch.setattr(
+        "vijil_dome.trust.adapters.langgraph.secure_graph", _fake_secure_graph
+    )
+    result = auto.secure_agent(
+        SimpleNamespace(),
+        agent_id="a",
+        constraints={},
+        heartbeat_interval=_INTERVAL,
+        beacon_signer=_SIGNER,
+    )
+    assert result == "wrapped"
+    assert captured["heartbeat_interval"] == _INTERVAL
+    assert captured["beacon_signer"] is _SIGNER

--- a/vijil_dome/tests/trust/test_beacon_signing.py
+++ b/vijil_dome/tests/trust/test_beacon_signing.py
@@ -19,6 +19,7 @@ from cryptography.x509.oid import NameOID
 
 from vijil_dome.trust.audit import AuditEmitter, BeaconSignature, Heartbeat
 from vijil_dome.trust.signing import (
+    _SIGNED_FIELDS,
     UnwiredBeaconSigner,
     X509BeaconSigner,
     canonical_beacon_payload,
@@ -165,6 +166,13 @@ def test_canonical_payload_changes_with_content() -> None:
 
 def test_heartbeat_signature_field_defaults_none() -> None:
     assert _beacon().signature is None
+
+
+def test_signed_fields_match_heartbeat_model() -> None:
+    # Drift guard: every identity-bearing Heartbeat field (all but the signature
+    # itself) must be covered by the signed payload. A new field left out would
+    # ship unsigned and tamperable.
+    assert _SIGNED_FIELDS == set(Heartbeat.model_fields) - {"signature"}
 
 
 def test_emit_heartbeat_carries_signature_in_attributes() -> None:

--- a/vijil_dome/tests/trust/test_beacon_signing.py
+++ b/vijil_dome/tests/trust/test_beacon_signing.py
@@ -1,0 +1,197 @@
+"""Tests for the BeaconSigner seam (DOME-169).
+
+A signed heartbeat proves the beacon was emitted by the attested principal it
+names, so a forged or replayed "I am enforcing" beacon is detectable. These
+tests exercise the real ECDSA/RSA sign-and-verify path with a synthetic key —
+the live-SVID wiring is deferred to DOME-179.
+"""
+
+from __future__ import annotations
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+from vijil_dome.trust.audit import AuditEmitter, BeaconSignature, Heartbeat
+from vijil_dome.trust.signing import (
+    UnwiredBeaconSigner,
+    X509BeaconSigner,
+    canonical_beacon_payload,
+    verify_beacon_signature,
+)
+
+_SPIFFE = "spiffe://vijil.ai/org/team/agent/uuid"
+
+
+def _self_signed(
+    spiffe_id: str, key: ec.EllipticCurvePrivateKey | rsa.RSAPrivateKey | None = None
+) -> tuple[ec.EllipticCurvePrivateKey | rsa.RSAPrivateKey, x509.Certificate]:
+    """Build a synthetic SVID-shaped self-signed cert carrying a SPIFFE SAN."""
+    signing_key = key or ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-agent")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(signing_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC))
+        .not_valid_after(datetime.datetime(2030, 1, 1, tzinfo=datetime.UTC))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(spiffe_id)]),
+            critical=False,
+        )
+        .sign(signing_key, hashes.SHA256())
+    )
+    return signing_key, cert
+
+
+def _beacon(**overrides: object) -> Heartbeat:
+    fields: dict[str, object] = {
+        "configured_mode": "enforce",
+        "guards_constructed": True,
+        "detector_reachable": True,
+        "attested": True,
+        "agent_spiffe_id": _SPIFFE,
+    }
+    fields.update(overrides)
+    return Heartbeat(**fields)  # type: ignore[arg-type]
+
+
+def test_x509_signer_round_trip_ec() -> None:
+    key, cert = _self_signed(_SPIFFE)
+    sig = X509BeaconSigner(key, cert).sign(_beacon())
+    assert sig is not None
+    assert sig.alg == "ES256"
+    assert sig.signed_subject == _SPIFFE
+    assert verify_beacon_signature(_beacon(), sig) is True
+
+
+def test_rsa_signer_round_trip() -> None:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    _, cert = _self_signed(_SPIFFE, key=key)
+    sig = X509BeaconSigner(key, cert).sign(_beacon())
+    assert sig is not None
+    assert sig.alg == "RS256"
+    assert verify_beacon_signature(_beacon(), sig) is True
+
+
+def test_tampered_beacon_fails_verification() -> None:
+    # ADVERSARIAL: a beacon signed in enforce posture must not verify when a
+    # downgraded warn posture is presented under the same signature.
+    key, cert = _self_signed(_SPIFFE)
+    sig = X509BeaconSigner(key, cert).sign(_beacon(configured_mode="enforce"))
+    assert sig is not None
+    assert verify_beacon_signature(_beacon(configured_mode="warn"), sig) is False
+
+
+def test_signature_from_wrong_key_fails_verification() -> None:
+    # ADVERSARIAL: signed by key A but carrying cert B (mismatched public key).
+    key_a, _ = _self_signed(_SPIFFE)
+    _, cert_b = _self_signed(_SPIFFE)
+    sig = X509BeaconSigner(key_a, cert_b).sign(_beacon())
+    assert sig is not None
+    assert verify_beacon_signature(_beacon(), sig) is False
+
+
+def test_impersonation_san_mismatch_fails_verification() -> None:
+    # ADVERSARIAL: an attacker holding a VALID SVID (key + cert) signs a beacon
+    # naming the victim's spiffe id. The signature math is sound, but the cert's
+    # SAN names the attacker, so verification must reject the impersonation.
+    attacker = "spiffe://vijil.ai/org/team/agent/attacker"
+    victim = "spiffe://vijil.ai/org/team/agent/victim"
+    key, cert = _self_signed(attacker)
+    sig = X509BeaconSigner(key, cert).sign(_beacon(agent_spiffe_id=victim))
+    assert sig is not None
+    assert verify_beacon_signature(_beacon(agent_spiffe_id=victim), sig) is False
+
+
+def test_x509_signer_declines_unattested_beacon() -> None:
+    # An unattested beacon names no principal; signing it would attest nothing.
+    key, cert = _self_signed(_SPIFFE)
+    sig = X509BeaconSigner(key, cert).sign(_beacon(attested=False, agent_spiffe_id=None))
+    assert sig is None
+
+
+def test_from_svid_constructs_working_signer() -> None:
+    key, cert = _self_signed(_SPIFFE)
+    fake_svid = SimpleNamespace(private_key=key, leaf=cert)
+    signer = X509BeaconSigner.from_svid(fake_svid)
+    sig = signer.sign(_beacon())
+    assert sig is not None
+    assert verify_beacon_signature(_beacon(), sig) is True
+
+
+def test_verify_rejects_empty_cert_chain() -> None:
+    bad = BeaconSignature(alg="ES256", signature="AA==", cert_chain=[], signed_subject=_SPIFFE)
+    assert verify_beacon_signature(_beacon(), bad) is False
+
+
+def test_unwired_signer_returns_none() -> None:
+    assert UnwiredBeaconSigner().sign(_beacon()) is None
+
+
+def test_unsupported_key_type_raises() -> None:
+    # BOUNDARY: a non-EC/RSA key must fail loud, never emit a bogus signature.
+    _, cert = _self_signed(_SPIFFE)
+
+    class _FakeKey:
+        pass
+
+    with pytest.raises(TypeError):
+        X509BeaconSigner(_FakeKey(), cert).sign(_beacon())  # type: ignore[arg-type]
+
+
+def test_canonical_payload_excludes_signature_field() -> None:
+    plain = _beacon()
+    with_sig = _beacon(
+        signature=BeaconSignature(
+            alg="ES256", signature="zz", cert_chain=["pem"], signed_subject=_SPIFFE
+        )
+    )
+    assert canonical_beacon_payload(plain) == canonical_beacon_payload(with_sig)
+
+
+def test_canonical_payload_changes_with_content() -> None:
+    assert canonical_beacon_payload(_beacon(detector_reachable=True)) != (
+        canonical_beacon_payload(_beacon(detector_reachable=False))
+    )
+
+
+def test_heartbeat_signature_field_defaults_none() -> None:
+    assert _beacon().signature is None
+
+
+def test_emit_heartbeat_carries_signature_in_attributes() -> None:
+    events: list[object] = []
+    emitter = AuditEmitter(agent_id="a", sink=events.append)
+    sig = BeaconSignature(
+        alg="ES256", signature="zz", cert_chain=["pem"], signed_subject=_SPIFFE
+    )
+    emitter.emit_heartbeat(
+        configured_mode="enforce",
+        guards_constructed=True,
+        detector_reachable=True,
+        attested=True,
+        agent_spiffe_id=_SPIFFE,
+        signature=sig,
+    )
+    assert events[0].attributes["signature"]["alg"] == "ES256"  # type: ignore[attr-defined]
+
+
+def test_emit_heartbeat_without_signature_records_none() -> None:
+    events: list[object] = []
+    emitter = AuditEmitter(agent_id="a", sink=events.append)
+    emitter.emit_heartbeat(
+        configured_mode="warn",
+        guards_constructed=False,
+        detector_reachable=False,
+        attested=False,
+        agent_spiffe_id=None,
+    )
+    assert events[0].attributes["signature"] is None  # type: ignore[attr-defined]

--- a/vijil_dome/tests/trust/test_beacon_signing.py
+++ b/vijil_dome/tests/trust/test_beacon_signing.py
@@ -128,6 +128,16 @@ def test_from_svid_constructs_working_signer() -> None:
     assert verify_beacon_signature(_beacon(), sig) is True
 
 
+def test_verify_rejects_mismatched_signed_subject() -> None:
+    # ADVERSARIAL: a genuine signature whose envelope signed_subject was swapped
+    # must not verify, so a verified beacon's signed_subject is authoritative.
+    key, cert = _self_signed(_SPIFFE)
+    sig = X509BeaconSigner(key, cert).sign(_beacon())
+    assert sig is not None
+    tampered = sig.model_copy(update={"signed_subject": "spiffe://vijil.ai/org/t/agent/other"})
+    assert verify_beacon_signature(_beacon(), tampered) is False
+
+
 def test_verify_rejects_empty_cert_chain() -> None:
     bad = BeaconSignature(alg="ES256", signature="AA==", cert_chain=[], signed_subject=_SPIFFE)
     assert verify_beacon_signature(_beacon(), bad) is False

--- a/vijil_dome/tests/trust/test_heartbeat_e2e.py
+++ b/vijil_dome/tests/trust/test_heartbeat_e2e.py
@@ -1,0 +1,176 @@
+"""End-to-end heartbeat: real runtime, real loop, signing, probe, liveness (DOME-169 Task 3.2).
+
+Drives a real ``TrustRuntime`` — not mocks of the unit under test — through the
+whole beacon path: the scheduler thread emits on a cadence, the reachability
+probe reflects the (stubbed) backend, a synthetic-key ``X509BeaconSigner`` signs
+each beacon so it verifies against the carried cert, and ``heartbeat_health``
+reports liveness in-process. The unsigned default is exercised too.
+"""
+
+from __future__ import annotations
+
+import datetime
+import threading
+import time
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from vijil_dome.trust.audit import AuditEvent
+from vijil_dome.trust.constraints import AgentConstraints
+from vijil_dome.trust.runtime import TrustRuntime
+from vijil_dome.trust.signing import X509BeaconSigner, verify_beacon_signature
+
+_SPIFFE = "spiffe://vijil.ai/org/team/agent/uuid"
+
+
+def _wait_until(predicate: Callable[[], bool], *, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+def _self_signed(spiffe_id: str) -> tuple[ec.EllipticCurvePrivateKey, x509.Certificate]:
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "e2e-agent")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC))
+        .not_valid_after(datetime.datetime(2030, 1, 1, tzinfo=datetime.UTC))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(spiffe_id)]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def _constraints() -> AgentConstraints:
+    return AgentConstraints.model_validate(
+        {
+            "agent_id": "agent-1",
+            "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+            "tool_permissions": [],
+            "organization": {
+                "required_input_guards": [],
+                "required_output_guards": [],
+                "denied_tools": [],
+            },
+            "enforcement_mode": "enforce",
+            "updated_at": "2026-04-03T12:00:00+00:00",
+        }
+    )
+
+
+def _runtime() -> TrustRuntime:
+    client = MagicMock()
+    client._http._token = "test-api-key"
+    client._http.get.return_value = _constraints().model_dump(mode="json")
+    return TrustRuntime(client=client, agent_id="agent-1", mode="warn")
+
+
+def _attested_identity(spiffe_id: str) -> MagicMock:
+    identity = MagicMock()
+    identity.is_attested.return_value = True
+    identity.spiffe_id = spiffe_id
+    return identity
+
+
+class _StubScanResult:
+    def __init__(self, errored_methods: list[str] | None = None) -> None:
+        self.errored_methods = errored_methods or []
+
+
+class _StubDome:
+    def __init__(self, *, errored: bool = False) -> None:
+        self.input_guardrail = object()
+        self.output_guardrail = None
+        self._errored = errored
+
+    def guard_input(self, text: str) -> _StubScanResult:
+        return _StubScanResult(["pi-detector"] if self._errored else [])
+
+
+def test_e2e_signed_beacon_verifies_against_carried_cert() -> None:
+    key, cert = _self_signed(_SPIFFE)
+    runtime = _runtime()
+    runtime._identity = _attested_identity(_SPIFFE)
+    runtime._beacon_signer = X509BeaconSigner(key, cert)
+    runtime._dome = _StubDome()
+
+    heartbeat = runtime.emit_heartbeat()
+
+    assert heartbeat.detector_reachable is True
+    assert heartbeat.attested is True
+    assert heartbeat.signature is not None
+    assert heartbeat.signature.signed_subject == _SPIFFE
+    assert verify_beacon_signature(heartbeat, heartbeat.signature) is True
+
+
+def test_e2e_tampered_beacon_fails_verification() -> None:
+    # The primitive's whole point: a downgraded "I am enforcing" beacon emitted
+    # by the real runtime must NOT verify under its own signature.
+    key, cert = _self_signed(_SPIFFE)
+    runtime = _runtime()
+    runtime._identity = _attested_identity(_SPIFFE)
+    runtime._beacon_signer = X509BeaconSigner(key, cert)
+    runtime._dome = _StubDome()
+
+    heartbeat = runtime.emit_heartbeat()
+    assert heartbeat.signature is not None
+    forged = heartbeat.model_copy(update={"configured_mode": "warn"})
+    assert verify_beacon_signature(forged, heartbeat.signature) is False
+
+
+def test_e2e_unsigned_by_default_for_unattested_agent() -> None:
+    runtime = _runtime()  # unattested api-key identity, default UnwiredBeaconSigner
+    runtime._dome = _StubDome()
+    heartbeat = runtime.emit_heartbeat()
+    assert heartbeat.signature is None
+
+
+def test_e2e_detector_unreachable_when_backend_errors() -> None:
+    runtime = _runtime()
+    runtime._dome = _StubDome(errored=True)
+    heartbeat = runtime.emit_heartbeat()
+    assert heartbeat.guards_constructed is True
+    assert heartbeat.detector_reachable is False
+
+
+def test_e2e_scheduler_emits_signed_beacons_and_reports_alive() -> None:
+    key, cert = _self_signed(_SPIFFE)
+    runtime = _runtime()
+    runtime._identity = _attested_identity(_SPIFFE)
+    runtime._beacon_signer = X509BeaconSigner(key, cert)
+    runtime._dome = _StubDome()
+    captured: list[AuditEvent] = []
+    beat = threading.Event()
+
+    def sink(event: AuditEvent) -> None:
+        captured.append(event)
+        beat.set()
+
+    runtime._audit._sink = sink
+    runtime.start_heartbeat(interval=0.01)
+    try:
+        assert beat.wait(timeout=2.0)
+        assert _wait_until(lambda: runtime.heartbeat_health().alive, timeout=2.0)
+        beacons = [e for e in captured if e.event_type == "enforcement_heartbeat"]
+        signature = beacons[-1].attributes["signature"]
+        assert signature is not None
+        assert signature["signed_subject"] == _SPIFFE
+    finally:
+        runtime.stop_heartbeat()
+    assert runtime.heartbeat_health().running is False

--- a/vijil_dome/tests/trust/test_heartbeat_probe.py
+++ b/vijil_dome/tests/trust/test_heartbeat_probe.py
@@ -1,0 +1,176 @@
+"""Real, bounded detector-reachability probe for the heartbeat (DOME-169 Task 2.1).
+
+``detector_reachable`` must mean "the detector backend actually responds," not
+merely "a Dome instance was constructed." The guard engine catches a failing
+detector internally and records it in ``ScanResult.errored_methods`` rather than
+raising, so the probe reads reachability from that field — across whichever
+guardrail (input and/or output) is actually configured — and caches the result
+for a TTL so the real detectors run at most once per heartbeat cadence.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from vijil_dome.trust.audit import AuditEvent
+from vijil_dome.trust.constraints import AgentConstraints
+from vijil_dome.trust.runtime import TrustRuntime
+
+
+def _constraints() -> AgentConstraints:
+    return AgentConstraints.model_validate(
+        {
+            "agent_id": "agent-1",
+            "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+            "tool_permissions": [],
+            "organization": {
+                "required_input_guards": [],
+                "required_output_guards": [],
+                "denied_tools": [],
+            },
+            "enforcement_mode": "enforce",
+            "updated_at": "2026-04-03T12:00:00+00:00",
+        }
+    )
+
+
+def _runtime() -> TrustRuntime:
+    client = MagicMock()
+    client._http._token = "test-api-key"  # api-key path -> unattested
+    client._http.get.return_value = _constraints().model_dump(mode="json")
+    return TrustRuntime(client=client, agent_id="agent-1", mode="warn")
+
+
+class _StubScanResult:
+    def __init__(self, errored_methods: list[str] | None = None) -> None:
+        self.errored_methods = errored_methods or []
+
+
+class _StubDome:
+    """A Dome stand-in mirroring the real guard contract.
+
+    The real Dome records a failing detector in ``errored_methods`` and returns
+    a normal ``ScanResult`` — it does NOT raise. The stub does the same so the
+    tests exercise the contract production actually honors. ``raises`` simulates
+    the rarer non-detector failure path.
+    """
+
+    def __init__(
+        self,
+        *,
+        errored: bool = False,
+        raises: bool = False,
+        has_input: bool = True,
+        has_output: bool = False,
+    ) -> None:
+        self.calls = 0
+        self._errored = errored
+        self._raises = raises
+        self.input_guardrail = object() if has_input else None
+        self.output_guardrail = object() if has_output else None
+
+    def _scan(self, label: str) -> _StubScanResult:
+        self.calls += 1
+        if self._raises:
+            raise RuntimeError("guard engine crashed")
+        return _StubScanResult(errored_methods=[label] if self._errored else [])
+
+    def guard_input(self, text: str) -> _StubScanResult:
+        return self._scan("pi-detector")
+
+    def guard_output(self, text: str) -> _StubScanResult:
+        return self._scan("toxicity-detector")
+
+
+def test_probe_false_when_no_guards_configured() -> None:
+    runtime = _runtime()  # empty guards -> _dome is None
+    assert runtime._probe_detector_reachable() is False
+
+
+def test_probe_false_when_guards_disabled() -> None:
+    runtime = _runtime()
+    runtime._dome = _StubDome()
+    runtime._guards_disabled = True
+    assert runtime._probe_detector_reachable() is False
+
+
+def test_probe_true_when_backend_responds() -> None:
+    runtime = _runtime()
+    runtime._dome = _StubDome(errored=False)
+    assert runtime._probe_detector_reachable() is True
+
+
+def test_probe_false_when_detector_errors() -> None:
+    # The key case: the real Dome does NOT raise on a dead backend — it records
+    # the detector in errored_methods. A probe that only caught exceptions would
+    # report this dead backend as reachable.
+    runtime = _runtime()
+    runtime._dome = _StubDome(errored=True)
+    assert runtime._probe_detector_reachable() is False
+
+
+def test_probe_false_when_backend_raises() -> None:
+    # Defensive: a non-detector failure (engine crash) also reads as unreachable.
+    runtime = _runtime()
+    runtime._dome = _StubDome(raises=True)
+    assert runtime._probe_detector_reachable() is False
+
+
+def test_probe_uses_output_guardrail_when_only_output_configured() -> None:
+    # An output-only config: guard_input is a no-op, so the probe must exercise
+    # the output guardrail or it would falsely report reachable.
+    runtime = _runtime()
+    runtime._dome = _StubDome(has_input=False, has_output=True, errored=False)
+    assert runtime._probe_detector_reachable() is True
+
+
+def test_probe_false_when_output_only_detector_errors() -> None:
+    runtime = _runtime()
+    runtime._dome = _StubDome(has_input=False, has_output=True, errored=True)
+    assert runtime._probe_detector_reachable() is False
+
+
+def test_probe_false_when_dome_has_no_guardrails() -> None:
+    runtime = _runtime()
+    runtime._dome = _StubDome(has_input=False, has_output=False)
+    assert runtime._probe_detector_reachable() is False
+
+
+def test_probe_caches_within_ttl() -> None:
+    runtime = _runtime()
+    stub = _StubDome()
+    runtime._dome = stub
+    assert runtime._probe_detector_reachable() is True
+    assert runtime._probe_detector_reachable() is True
+    assert stub.calls == 1  # second call served from cache
+
+
+def test_probe_reruns_after_ttl_expires() -> None:
+    runtime = _runtime()
+    stub = _StubDome()
+    runtime._dome = stub
+    fake_now = [0.0]
+    runtime._clock = lambda: fake_now[0]
+    runtime._detector_probe_ttl_s = 10.0
+
+    assert runtime._probe_detector_reachable() is True  # probe at t=0
+    fake_now[0] = 5.0
+    assert runtime._probe_detector_reachable() is True  # within TTL -> cached
+    assert stub.calls == 1
+    fake_now[0] = 20.0
+    assert runtime._probe_detector_reachable() is True  # TTL expired -> re-probe
+    assert stub.calls == 2
+
+
+def test_emit_heartbeat_distinguishes_constructed_from_reachable() -> None:
+    # The core semantic: a built-but-unreachable backend reports
+    # guards_constructed=True AND detector_reachable=False.
+    events: list[AuditEvent] = []
+    runtime = _runtime()
+    runtime._dome = _StubDome(errored=True)
+    runtime._audit._sink = events.append
+
+    runtime.emit_heartbeat()
+
+    assert events[-1].attributes["guards_constructed"] is True
+    assert events[-1].attributes["detector_reachable"] is False

--- a/vijil_dome/tests/trust/test_heartbeat_scheduler.py
+++ b/vijil_dome/tests/trust/test_heartbeat_scheduler.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import threading
 import time
 from collections.abc import Callable
+from threading import Thread
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -211,16 +213,29 @@ def test_health_not_alive_before_first_emit() -> None:
     assert health.running is False
 
 
-def test_health_alive_when_recent_then_stale() -> None:
+def test_health_alive_when_running_and_recent_then_stale() -> None:
     runtime = _runtime()
+    # simulate a running loop thread (only is_alive() is read by heartbeat_health)
+    runtime._heartbeat_thread = cast(Thread, SimpleNamespace(is_alive=lambda: True))
     now = [0.0]
     runtime._clock = lambda: now[0]
     runtime._heartbeat_interval = 10.0
     runtime._last_emit_at = 0.0
 
-    now[0] = 15.0  # within 2x interval (20s)
+    now[0] = 15.0  # running + within 2x interval (20s)
     assert runtime.heartbeat_health().alive is True
-    now[0] = 25.0  # past the staleness threshold -> a dead loop is loud
+    now[0] = 25.0  # past the staleness threshold -> a stuck loop is loud
+    assert runtime.heartbeat_health().alive is False
+
+
+def test_health_not_alive_after_stop_even_if_recent() -> None:
+    # A stopped (non-running) scheduler must not report alive, even when the last
+    # emit is recent — otherwise alive lingers True for up to 2x interval.
+    runtime = _runtime()
+    runtime._clock = lambda: 0.0
+    runtime._heartbeat_interval = 10.0
+    runtime._last_emit_at = 0.0  # very recent
+    assert runtime.heartbeat_health().running is False
     assert runtime.heartbeat_health().alive is False
 
 

--- a/vijil_dome/tests/trust/test_heartbeat_scheduler.py
+++ b/vijil_dome/tests/trust/test_heartbeat_scheduler.py
@@ -1,0 +1,232 @@
+"""Supervised heartbeat scheduler + in-process liveness self-check (DOME-169 Task 2.2).
+
+A daemon thread emits the beacon on a cadence; ``heartbeat_health()`` lets a host
+(or B4) detect a dead or stalled loop *in-process*, without waiting on the
+Console reconciler. ``emit_heartbeat`` signs each beacon via the injected
+``BeaconSigner`` (default unsigned). Tests synchronize on the emitted beacon via
+a ``threading.Event`` and drive the liveness math with an injected clock — no
+fixed sleeps.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vijil_dome.trust.audit import AuditEvent, BeaconSignature, Heartbeat
+from vijil_dome.trust.constraints import AgentConstraints
+from vijil_dome.trust.runtime import TrustRuntime
+
+
+def _wait_until(predicate: Callable[[], bool], *, timeout: float) -> bool:
+    """Poll until predicate is true or the timeout elapses (bounded, non-flaky)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+def _constraints() -> AgentConstraints:
+    return AgentConstraints.model_validate(
+        {
+            "agent_id": "agent-1",
+            "dome_config": {"input_guards": [], "output_guards": [], "guards": {}},
+            "tool_permissions": [],
+            "organization": {
+                "required_input_guards": [],
+                "required_output_guards": [],
+                "denied_tools": [],
+            },
+            "enforcement_mode": "enforce",
+            "updated_at": "2026-04-03T12:00:00+00:00",
+        }
+    )
+
+
+def _runtime(*, heartbeat_interval: float | None = None) -> TrustRuntime:
+    client = MagicMock()
+    client._http._token = "test-api-key"
+    client._http.get.return_value = _constraints().model_dump(mode="json")
+    return TrustRuntime(
+        client=client,
+        agent_id="agent-1",
+        mode="warn",
+        heartbeat_interval=heartbeat_interval,
+    )
+
+
+class _FakeSigner:
+    """A BeaconSigner that always returns a fixed signature."""
+
+    def sign(self, beacon: Heartbeat) -> BeaconSignature:
+        return BeaconSignature(
+            alg="ES256",
+            signature="zz",
+            cert_chain=["pem"],
+            signed_subject="spiffe://vijil.ai/org/t/agent/u",
+        )
+
+
+def _raising_sink(event: AuditEvent) -> None:
+    raise RuntimeError("audit sink down")
+
+
+# --- signer wiring ---------------------------------------------------------
+
+
+def test_emit_heartbeat_unsigned_by_default() -> None:
+    events: list[AuditEvent] = []
+    runtime = _runtime()
+    runtime._audit._sink = events.append
+    hb = runtime.emit_heartbeat()
+    assert hb.signature is None
+    assert events[-1].attributes["signature"] is None
+
+
+def test_emit_heartbeat_attaches_signature_from_signer() -> None:
+    events: list[AuditEvent] = []
+    runtime = _runtime()
+    runtime._beacon_signer = _FakeSigner()
+    runtime._audit._sink = events.append
+    hb = runtime.emit_heartbeat()
+    assert hb.signature is not None
+    assert hb.signature.alg == "ES256"
+    assert events[-1].attributes["signature"]["alg"] == "ES256"
+
+
+# --- per-tick resilience ---------------------------------------------------
+
+
+def test_emit_safely_advances_last_emit_at() -> None:
+    runtime = _runtime()
+    runtime._clock = lambda: 42.0
+    runtime._emit_heartbeat_safely()
+    assert runtime._last_emit_at == 42.0
+
+
+def test_emit_safely_survives_sink_failure() -> None:
+    # A failing emit must not kill the loop, and must NOT advance last_emit_at
+    # (so the staleness signal grows -> heartbeat_health turns not-alive).
+    runtime = _runtime()
+    runtime._audit._sink = _raising_sink
+    runtime._emit_heartbeat_safely()  # must not raise
+    assert runtime._last_emit_at is None
+
+
+# --- thread lifecycle ------------------------------------------------------
+
+
+def test_scheduler_runs_and_stops() -> None:
+    runtime = _runtime()
+    beat = threading.Event()
+    runtime._audit._sink = lambda event: beat.set()
+    runtime.start_heartbeat(interval=0.01)
+    try:
+        assert beat.wait(timeout=2.0)  # a beacon was emitted
+        assert runtime.heartbeat_health().running is True
+        # the real loop advances _last_emit_at, so alive becomes True end-to-end
+        assert _wait_until(lambda: runtime.heartbeat_health().alive, timeout=2.0)
+    finally:
+        runtime.stop_heartbeat()
+    assert runtime.heartbeat_health().running is False
+
+
+def test_start_heartbeat_rejects_nonpositive_interval() -> None:
+    runtime = _runtime()
+    with pytest.raises(ValueError, match="positive"):
+        runtime.start_heartbeat(interval=0)
+    with pytest.raises(ValueError, match="positive"):
+        runtime.start_heartbeat(interval=-1.0)
+
+
+def test_stop_keeps_handle_when_thread_does_not_exit() -> None:
+    # When the loop is stuck in a hung probe past the join timeout, stop must NOT
+    # orphan the thread (which would let a later start spawn a duplicate); it keeps
+    # the handle, logs, and the thread exits once the probe returns.
+    runtime = _runtime()
+    runtime._heartbeat_join_timeout_s = 0.05
+    entered = threading.Event()
+    release = threading.Event()
+
+    class _HangingDome:
+        input_guardrail = object()
+        output_guardrail = None
+
+        def guard_input(self, text: str) -> SimpleNamespace:
+            entered.set()
+            release.wait(timeout=5.0)  # hang until the test releases it
+            return SimpleNamespace(errored_methods=[])
+
+    runtime._dome = _HangingDome()
+    runtime.start_heartbeat(interval=0.01)
+    try:
+        assert entered.wait(timeout=2.0)  # thread is now stuck in the probe
+        runtime.stop_heartbeat()  # join times out while the probe hangs
+        assert runtime._heartbeat_thread is not None  # handle kept, not orphaned
+        assert runtime._heartbeat_thread.is_alive()
+    finally:
+        release.set()  # let the probe return so the loop can exit
+        assert _wait_until(
+            lambda: not runtime.heartbeat_health().running, timeout=2.0
+        )
+        runtime.stop_heartbeat()  # joins cleanly now, clears the handle
+    assert runtime._heartbeat_thread is None
+
+
+def test_stop_heartbeat_is_idempotent() -> None:
+    runtime = _runtime()
+    runtime.start_heartbeat(interval=0.01)
+    runtime.stop_heartbeat()
+    runtime.stop_heartbeat()  # second call must not raise
+    assert runtime.heartbeat_health().running is False
+
+
+def test_start_heartbeat_is_idempotent_while_running() -> None:
+    runtime = _runtime()
+    runtime.start_heartbeat(interval=0.01)
+    try:
+        first = runtime._heartbeat_thread
+        runtime.start_heartbeat(interval=0.01)  # no-op while alive
+        assert runtime._heartbeat_thread is first
+    finally:
+        runtime.stop_heartbeat()
+
+
+# --- in-process liveness self-check ---------------------------------------
+
+
+def test_health_not_alive_before_first_emit() -> None:
+    runtime = _runtime()
+    runtime._heartbeat_interval = 10.0
+    health = runtime.heartbeat_health()
+    assert health.last_emit_age_s is None
+    assert health.alive is False
+    assert health.running is False
+
+
+def test_health_alive_when_recent_then_stale() -> None:
+    runtime = _runtime()
+    now = [0.0]
+    runtime._clock = lambda: now[0]
+    runtime._heartbeat_interval = 10.0
+    runtime._last_emit_at = 0.0
+
+    now[0] = 15.0  # within 2x interval (20s)
+    assert runtime.heartbeat_health().alive is True
+    now[0] = 25.0  # past the staleness threshold -> a dead loop is loud
+    assert runtime.heartbeat_health().alive is False
+
+
+def test_constructor_auto_starts_when_interval_set() -> None:
+    runtime = _runtime(heartbeat_interval=0.01)
+    try:
+        assert runtime.heartbeat_health().running is True
+    finally:
+        runtime.stop_heartbeat()

--- a/vijil_dome/trust/adapters/adk.py
+++ b/vijil_dome/trust/adapters/adk.py
@@ -17,6 +17,7 @@ from vijil_dome.trust.adapters.base import BaseAdapter, register_adapter
 
 from vijil_dome.trust.constraints import AgentConstraints
 from vijil_dome.trust.runtime import TrustRuntime
+from vijil_dome.trust.signing import BeaconSigner
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ def secure_agent(
     constraints: AgentConstraints | dict[str, Any] | None = None,
     manifest: Any = None,
     mode: str = "warn",
+    heartbeat_interval: float | None = None,
+    beacon_signer: BeaconSigner | None = None,
 ) -> Any:
     """Add trust enforcement to a Google ADK Agent via callbacks.
 
@@ -54,6 +57,10 @@ def secure_agent(
         Optional signed tool manifest.
     mode:
         ``"warn"`` or ``"enforce"``.
+    heartbeat_interval:
+        If set, auto-start an enforcement-heartbeat thread on this cadence.
+    beacon_signer:
+        Optional signer for heartbeat beacons (unsigned by default).
 
     Returns
     -------
@@ -74,6 +81,8 @@ def secure_agent(
         constraints=constraints,
         manifest=manifest,
         mode=mode,
+        heartbeat_interval=heartbeat_interval,
+        beacon_signer=beacon_signer,
     )
 
     # Store runtime on the agent for external access

--- a/vijil_dome/trust/adapters/auto.py
+++ b/vijil_dome/trust/adapters/auto.py
@@ -24,6 +24,7 @@ import logging
 from typing import Any
 
 from vijil_dome.trust.constraints import AgentConstraints
+from vijil_dome.trust.signing import BeaconSigner
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,8 @@ def secure_agent(
     constraints: AgentConstraints | dict[str, Any] | None = None,
     manifest: Any = None,
     mode: str = "warn",
+    heartbeat_interval: float | None = None,
+    beacon_signer: BeaconSigner | None = None,
     **kwargs: Any,
 ) -> Any:
     """Add trust enforcement to any supported agent framework.
@@ -67,6 +70,11 @@ def secure_agent(
         Optional signed tool manifest.
     mode:
         ``"warn"`` or ``"enforce"``.
+    heartbeat_interval:
+        If set, the runtime auto-starts an enforcement-heartbeat thread on
+        this cadence (forwarded to every framework adapter).
+    beacon_signer:
+        Optional signer for heartbeat beacons (unsigned by default).
     **kwargs:
         Passed through to the framework-specific adapter (e.g.,
         ``compile_kwargs`` for LangGraph).
@@ -83,6 +91,8 @@ def secure_agent(
             constraints=constraints,
             manifest=manifest,
             mode=mode,
+            heartbeat_interval=heartbeat_interval,
+            beacon_signer=beacon_signer,
             **kwargs,
         )
 
@@ -96,6 +106,8 @@ def secure_agent(
             constraints=constraints,
             manifest=manifest,
             mode=mode,
+            heartbeat_interval=heartbeat_interval,
+            beacon_signer=beacon_signer,
         )
 
     if framework == "strands":
@@ -108,6 +120,8 @@ def secure_agent(
             constraints=constraints,
             manifest=manifest,
             mode=mode,
+            heartbeat_interval=heartbeat_interval,
+            beacon_signer=beacon_signer,
         )
 
     # Fallback: try the adapter registry for custom-registered adapters
@@ -122,6 +136,8 @@ def secure_agent(
             constraints=constraints,
             manifest=manifest,
             mode=mode,
+            heartbeat_interval=heartbeat_interval,
+            beacon_signer=beacon_signer,
             **kwargs,
         )
 

--- a/vijil_dome/trust/adapters/langgraph.py
+++ b/vijil_dome/trust/adapters/langgraph.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from vijil_dome.trust.adapters.base import BaseAdapter, register_adapter
 from vijil_dome.trust.runtime import TrustRuntime
+from vijil_dome.trust.signing import BeaconSigner
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +161,8 @@ def secure_graph(
     constraints: Any = None,
     manifest: Any = None,
     mode: str = "warn",
+    heartbeat_interval: float | None = None,
+    beacon_signer: BeaconSigner | None = None,
     **compile_kwargs: Any,
 ) -> SecureGraph:
     """Create a :class:`SecureGraph` from a LangGraph graph.
@@ -184,6 +187,10 @@ def secure_graph(
         Optional tool manifest (path or :class:`ToolManifest`).
     mode:
         ``"warn"`` (log violations) or ``"enforce"`` (block violations).
+    heartbeat_interval:
+        If set, auto-start an enforcement-heartbeat thread on this cadence.
+    beacon_signer:
+        Optional signer for heartbeat beacons (unsigned by default).
     **compile_kwargs:
         Passed to ``graph.compile()`` when compiling.
     """
@@ -193,6 +200,8 @@ def secure_graph(
         constraints=constraints,
         manifest=manifest,
         mode=mode,
+        heartbeat_interval=heartbeat_interval,
+        beacon_signer=beacon_signer,
     )
 
     # Compile if needed

--- a/vijil_dome/trust/adapters/strands.py
+++ b/vijil_dome/trust/adapters/strands.py
@@ -17,6 +17,7 @@ from vijil_dome.trust.adapters.base import BaseAdapter, register_adapter
 
 from vijil_dome.trust.constraints import AgentConstraints
 from vijil_dome.trust.runtime import TrustRuntime
+from vijil_dome.trust.signing import BeaconSigner
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ def secure_agent(
     constraints: AgentConstraints | dict[str, Any] | None = None,
     manifest: Any = None,
     mode: str = "warn",
+    heartbeat_interval: float | None = None,
+    beacon_signer: BeaconSigner | None = None,
 ) -> Any:
     """Add trust enforcement to a Strands Agent.
 
@@ -56,6 +59,10 @@ def secure_agent(
         Optional signed tool manifest.
     mode:
         ``"warn"`` or ``"enforce"``.
+    heartbeat_interval:
+        If set, auto-start an enforcement-heartbeat thread on this cadence.
+    beacon_signer:
+        Optional signer for heartbeat beacons (unsigned by default).
 
     Returns
     -------
@@ -67,6 +74,8 @@ def secure_agent(
         constraints=constraints,
         manifest=manifest,
         mode=mode,
+        heartbeat_interval=heartbeat_interval,
+        beacon_signer=beacon_signer,
     )
 
     # Inject hooks into the agent
@@ -96,6 +105,8 @@ def create_trust_hooks(
     constraints: AgentConstraints | dict[str, Any] | None = None,
     manifest: Any = None,
     mode: str = "warn",
+    heartbeat_interval: float | None = None,
+    beacon_signer: BeaconSigner | None = None,
 ) -> Any:
     """Create a Strands HookProvider with trust enforcement.
 
@@ -123,6 +134,10 @@ def create_trust_hooks(
         Optional signed tool manifest.
     mode:
         ``"warn"`` or ``"enforce"``.
+    heartbeat_interval:
+        If set, auto-start an enforcement-heartbeat thread on this cadence.
+    beacon_signer:
+        Optional signer for heartbeat beacons (unsigned by default).
     """
     try:
         from strands.hooks import (
@@ -144,6 +159,8 @@ def create_trust_hooks(
         constraints=constraints,
         manifest=manifest,
         mode=mode,
+        heartbeat_interval=heartbeat_interval,
+        beacon_signer=beacon_signer,
     )
 
     class TrustHookProvider(HookProvider):

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -30,10 +30,11 @@ class BeaconSignature(BaseModel):
     Produced by an ``X509BeaconSigner`` from the agent's SVID so a downstream
     consumer (B4's liveness reconciler) can confirm a beacon was emitted by the
     attested principal it names — a forged or replayed "I am enforcing" beacon
-    fails verification. ``signed_subject`` is advisory: the authoritative binding
-    is enforced by ``verify_beacon_signature`` (the leaf cert's SPIFFE SAN must
-    equal the beacon's ``agent_spiffe_id``), so consumers MUST call it rather
-    than trusting ``signed_subject``. ``cert_chain`` is leaf-first PEM so the
+    fails verification. ``verify_beacon_signature`` enforces that BOTH the leaf
+    cert's SPIFFE SAN and this ``signed_subject`` equal the beacon's
+    ``agent_spiffe_id``; ``signed_subject`` is therefore trustworthy only after
+    verification — consumers MUST call ``verify_beacon_signature`` rather than
+    read it off an unverified blob. ``cert_chain`` is leaf-first PEM so the
     verifier can recover the public key and (Console-side) check it chains to
     the trust bundle.
     """

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -79,6 +79,21 @@ class Heartbeat(BaseModel):
     signature: BeaconSignature | None = None
 
 
+class HeartbeatHealth(BaseModel):
+    """In-process liveness view of the heartbeat scheduler.
+
+    Lets a host (or B4's reconciler) detect a dead or stalled emitter without
+    waiting on the Console staleness sweep. ``alive`` is derived from emit
+    recency, so it turns False whether the loop thread died or its ticks are
+    failing. ``running`` reports the thread directly; ``last_emit_age_s`` is the
+    seconds since the last successful emit, or ``None`` before the first.
+    """
+
+    running: bool
+    last_emit_age_s: float | None
+    alive: bool
+
+
 class AuditEmitter:
     """Emits structured audit events to a pluggable sink.
 

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
     from vijil_dome.trust.delta import TrustDelta, TrustVector
@@ -22,6 +22,26 @@ class AuditEvent(BaseModel):
     agent_id: str
     timestamp: datetime
     attributes: dict[str, Any]
+
+
+class BeaconSignature(BaseModel):
+    """A detached signature over a heartbeat's identity-bearing fields.
+
+    Produced by an ``X509BeaconSigner`` from the agent's SVID so a downstream
+    consumer (B4's liveness reconciler) can confirm a beacon was emitted by the
+    attested principal it names — a forged or replayed "I am enforcing" beacon
+    fails verification. ``signed_subject`` is the SPIFFE id the signing key
+    attests; ``cert_chain`` is leaf-first PEM so the verifier can recover the
+    public key and (Console-side) check it chains to the trust bundle.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    alg: str
+    signature: str  # base64-encoded raw signature bytes
+    cert_chain: list[str]  # PEM certificates, leaf first
+    signed_subject: str  # the SPIFFE id the signing key attests; never None
+    # (X509BeaconSigner declines to sign an unattested beacon)
 
 
 class Heartbeat(BaseModel):
@@ -46,7 +66,9 @@ class Heartbeat(BaseModel):
       ``attested`` is False. Consumers MUST gate on ``attested`` before keying
       decisions on this value.
 
-    SVID-signing of the beacon and periodic scheduling are a follow-up (DOME-169).
+    - ``signature`` — a detached ``BeaconSignature`` over the identity-bearing
+      fields when an SVID-backed signer is wired, else ``None`` (the beacon
+      ships unsigned). Wiring the live signer to a real SVID is DOME-179.
     """
 
     configured_mode: str
@@ -54,6 +76,7 @@ class Heartbeat(BaseModel):
     detector_reachable: bool
     attested: bool
     agent_spiffe_id: str | None
+    signature: BeaconSignature | None = None
 
 
 class AuditEmitter:
@@ -123,12 +146,14 @@ class AuditEmitter:
         detector_reachable: bool,
         attested: bool,
         agent_spiffe_id: str | None = None,
+        signature: BeaconSignature | None = None,
     ) -> None:
         """Emit an enforcement-alive heartbeat ('I am enforcing') event.
 
         Carries the live enforcement posture so a registered agent that goes
-        dark or silently downgrades is detectable downstream. See
-        ``Heartbeat`` for field semantics. SVID-signing is a follow-up (DOME-169).
+        dark or silently downgrades is detectable downstream. See ``Heartbeat``
+        for field semantics. ``signature`` travels with the event (as a dict, or
+        ``None`` when unsigned) so a consumer can verify the beacon's origin.
         """
         self._emit(
             "enforcement_heartbeat",
@@ -137,6 +162,7 @@ class AuditEmitter:
             detector_reachable=detector_reachable,
             attested=attested,
             agent_spiffe_id=agent_spiffe_id,
+            signature=signature.model_dump() if signature is not None else None,
         )
 
     def emit_attestation(

--- a/vijil_dome/trust/audit.py
+++ b/vijil_dome/trust/audit.py
@@ -30,9 +30,12 @@ class BeaconSignature(BaseModel):
     Produced by an ``X509BeaconSigner`` from the agent's SVID so a downstream
     consumer (B4's liveness reconciler) can confirm a beacon was emitted by the
     attested principal it names — a forged or replayed "I am enforcing" beacon
-    fails verification. ``signed_subject`` is the SPIFFE id the signing key
-    attests; ``cert_chain`` is leaf-first PEM so the verifier can recover the
-    public key and (Console-side) check it chains to the trust bundle.
+    fails verification. ``signed_subject`` is advisory: the authoritative binding
+    is enforced by ``verify_beacon_signature`` (the leaf cert's SPIFFE SAN must
+    equal the beacon's ``agent_spiffe_id``), so consumers MUST call it rather
+    than trusting ``signed_subject``. ``cert_chain`` is leaf-first PEM so the
+    verifier can recover the public key and (Console-side) check it chains to
+    the trust bundle.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import threading
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -13,7 +14,12 @@ from urllib.parse import quote
 
 from vijil_dome.controls.models import Control, EvaluationResult
 from vijil_dome.trust.attestation import AttestationResult, ToolAttestationStatus
-from vijil_dome.trust.audit import AuditEmitter, AuditEvent, Heartbeat
+from vijil_dome.trust.audit import (
+    AuditEmitter,
+    AuditEvent,
+    Heartbeat,
+    HeartbeatHealth,
+)
 from vijil_dome.trust.constraints import AgentConstraints
 from vijil_dome.trust.delta import (
     TrustDelta,
@@ -25,6 +31,7 @@ from vijil_dome.trust.guard import EnforcementResult
 from vijil_dome.trust.identity import AgentIdentity
 from vijil_dome.trust.manifest import ToolManifest
 from vijil_dome.trust.policy import ToolCallResult, ToolPolicy
+from vijil_dome.trust.signing import BeaconSigner, UnwiredBeaconSigner
 
 logger = logging.getLogger(__name__)
 
@@ -47,11 +54,23 @@ class _ProbeResult(NamedTuple):
     reachable: bool
 
 
+# A heartbeat is considered stale (the emitter is not alive) once this many
+# intervals have elapsed since the last successful emit — one missed beat is
+# tolerated as jitter; two means the loop is dead or stuck.
+_HEARTBEAT_STALENESS_FACTOR = 2.0
+
+# How long stop_heartbeat waits for the loop thread to exit before giving up, so
+# a hung probe inside the thread cannot make stop block forever.
+_HEARTBEAT_JOIN_TIMEOUT_S = 5.0
+
+
 class TrustRuntime:
     """Core orchestrator composing identity, constraints, guards, MAC, and audit.
 
     Wires together all trust modules into a single object that agent
-    frameworks (LangGraph, CrewAI, etc.) can integrate with.
+    frameworks (LangGraph, CrewAI, etc.) can integrate with. Passing
+    ``heartbeat_interval`` auto-starts a daemon thread that emits enforcement
+    beacons on that cadence (opt-in; off by default).
     """
 
     def __init__(
@@ -64,6 +83,8 @@ class TrustRuntime:
         mode: str = "warn",
         spire_socket: str = "/run/spire/sockets/agent.sock",
         audit_sink: Callable[[AuditEvent], None] | None = None,
+        heartbeat_interval: float | None = None,
+        beacon_signer: BeaconSigner | None = None,
     ) -> None:
         _valid_modes = ("warn", "enforce")
         if mode not in _valid_modes:
@@ -202,6 +223,19 @@ class TrustRuntime:
         self._clock: Callable[[], float] = time.monotonic
         self._detector_probe_ttl_s: float = _DEFAULT_DETECTOR_PROBE_TTL_S
         self._detector_probe_cache: _ProbeResult | None = None
+
+        # 9. Heartbeat scheduler state. The signer defaults to unsigned; the
+        # scheduler is opt-in via heartbeat_interval and, when set, auto-starts
+        # here as a documented construction side effect (a daemon thread, so it
+        # never blocks process exit; one thread per runtime instance).
+        self._beacon_signer: BeaconSigner = beacon_signer or UnwiredBeaconSigner()
+        self._heartbeat_interval: float | None = heartbeat_interval
+        self._heartbeat_thread: threading.Thread | None = None
+        self._heartbeat_stop: threading.Event | None = None
+        self._heartbeat_join_timeout_s: float = _HEARTBEAT_JOIN_TIMEOUT_S
+        self._last_emit_at: float | None = None
+        if heartbeat_interval is not None:
+            self.start_heartbeat(heartbeat_interval)
 
     # ------------------------------------------------------------------
     # Trust vector
@@ -750,8 +784,10 @@ class TrustRuntime:
         the probe fails. ``attested`` gates the SPIFFE id: ``agent_spiffe_id``
         is only meaningful when ``attested`` is True.
 
-        SVID-signing of the beacon and periodic scheduling are wired by the
-        heartbeat scheduler (DOME-169).
+        The beacon is signed by the injected ``BeaconSigner`` (unsigned by
+        default); ``start_heartbeat`` drives this method on a cadence. Calling it
+        directly is fail-loud — a signer or audit-sink error propagates; the
+        scheduler path wraps it (see ``_emit_heartbeat_safely``).
         """
         attested = self._identity.is_attested()
         guards_constructed = self._dome is not None and not self._guards_disabled
@@ -763,11 +799,110 @@ class TrustRuntime:
             attested=attested,
             agent_spiffe_id=self._identity.spiffe_id if attested else None,
         )
+        signature = self._beacon_signer.sign(heartbeat)
+        heartbeat = heartbeat.model_copy(update={"signature": signature})
         self._audit.emit_heartbeat(
             configured_mode=heartbeat.configured_mode,
             guards_constructed=heartbeat.guards_constructed,
             detector_reachable=heartbeat.detector_reachable,
             attested=heartbeat.attested,
             agent_spiffe_id=heartbeat.agent_spiffe_id,
+            signature=signature,
         )
         return heartbeat
+
+    # ------------------------------------------------------------------
+    # Heartbeat scheduler (DOME-169)
+    # ------------------------------------------------------------------
+
+    def start_heartbeat(self, interval: float | None = None) -> None:
+        """Start the background heartbeat loop if it is not already running.
+
+        Spawns a daemon thread that emits a beacon every ``interval`` seconds.
+        Idempotent — a no-op while a loop is already alive. ``interval`` defaults
+        to the value given at construction.
+        """
+        resolved = interval if interval is not None else self._heartbeat_interval
+        if resolved is None or resolved <= 0:
+            raise ValueError("heartbeat interval must be a positive number of seconds")
+        if self._heartbeat_thread is not None and self._heartbeat_thread.is_alive():
+            return
+        self._heartbeat_interval = resolved
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=self._run_heartbeat_loop,
+            args=(stop, resolved),
+            name=f"dome-heartbeat-{self._agent_id}",
+            daemon=True,
+        )
+        self._heartbeat_stop = stop
+        self._heartbeat_thread = thread
+        thread.start()
+
+    def stop_heartbeat(self) -> None:
+        """Signal the heartbeat loop to stop and wait (bounded) for it to exit.
+
+        Idempotent. The join is bounded by ``_HEARTBEAT_JOIN_TIMEOUT_S`` so a
+        probe hung inside the loop cannot make stop block forever.
+        """
+        stop, thread = self._heartbeat_stop, self._heartbeat_thread
+        if stop is not None:
+            stop.set()
+        if thread is not None:
+            thread.join(timeout=self._heartbeat_join_timeout_s)
+            if thread.is_alive():
+                # The loop did not exit in time — a probe is likely hung. Keep the
+                # handle so start_heartbeat refuses to spawn a duplicate; the stop
+                # event is set, so the thread exits once the probe returns. Surface
+                # it loudly rather than silently orphaning the thread.
+                logger.warning(
+                    "heartbeat thread %s did not stop within %ss; it will exit when "
+                    "its in-flight probe returns",
+                    thread.name,
+                    self._heartbeat_join_timeout_s,
+                )
+                return
+        self._heartbeat_stop = None
+        self._heartbeat_thread = None
+
+    def _run_heartbeat_loop(self, stop: threading.Event, interval: float) -> None:
+        """Emit a beacon immediately, then once per ``interval`` until stopped.
+
+        ``stop.wait(interval)`` doubles as the sleep and the stop signal, so a
+        stop request interrupts the wait at once rather than after a full cycle.
+        """
+        self._emit_heartbeat_safely()
+        while not stop.wait(interval):
+            self._emit_heartbeat_safely()
+
+    def _emit_heartbeat_safely(self) -> None:
+        """Emit one beacon, advancing ``_last_emit_at`` only on success.
+
+        A failed emit is logged but never propagated, so a single failure cannot
+        kill the loop; because the timestamp advances only on success, a run of
+        failures grows the staleness that ``heartbeat_health`` surfaces.
+        """
+        try:
+            self.emit_heartbeat()
+        except Exception:  # noqa: BLE001 -- a tick failure must not kill the loop
+            logger.warning("heartbeat emit failed", exc_info=True)
+            return
+        self._last_emit_at = self._clock()
+
+    def heartbeat_health(self) -> HeartbeatHealth:
+        """Report the heartbeat's in-process liveness (see ``HeartbeatHealth``).
+
+        ``alive`` is derived from emit recency, so it turns False whether the
+        loop thread died or its ticks are failing — without waiting on the
+        Console staleness sweep.
+        """
+        thread = self._heartbeat_thread
+        running = thread is not None and thread.is_alive()
+        last = self._last_emit_at
+        age = None if last is None else self._clock() - last
+        interval = self._heartbeat_interval
+        threshold = (
+            interval * _HEARTBEAT_STALENESS_FACTOR if interval is not None else None
+        )
+        alive = age is not None and threshold is not None and age <= threshold
+        return HeartbeatHealth(running=running, last_emit_age_s=age, alive=alive)

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -892,9 +892,10 @@ class TrustRuntime:
     def heartbeat_health(self) -> HeartbeatHealth:
         """Report the heartbeat's in-process liveness (see ``HeartbeatHealth``).
 
-        ``alive`` is derived from emit recency, so it turns False whether the
-        loop thread died or its ticks are failing — without waiting on the
-        Console staleness sweep.
+        ``alive`` requires both a running loop AND a recent successful emit, so it
+        turns False immediately when the loop is stopped or its thread dies, and
+        also when a still-running loop's ticks are failing (staleness) — without
+        waiting on the Console staleness sweep.
         """
         thread = self._heartbeat_thread
         running = thread is not None and thread.is_alive()
@@ -904,5 +905,5 @@ class TrustRuntime:
         threshold = (
             interval * _HEARTBEAT_STALENESS_FACTOR if interval is not None else None
         )
-        alive = age is not None and threshold is not None and age <= threshold
-        return HeartbeatHealth(running=running, last_emit_age_s=age, alive=alive)
+        fresh = age is not None and threshold is not None and age <= threshold
+        return HeartbeatHealth(running=running, last_emit_age_s=age, alive=running and fresh)

--- a/vijil_dome/trust/runtime.py
+++ b/vijil_dome/trust/runtime.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import functools
 import logging
+import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 from urllib.parse import quote
 
 from vijil_dome.controls.models import Control, EvaluationResult
@@ -28,6 +29,22 @@ from vijil_dome.trust.policy import ToolCallResult, ToolPolicy
 logger = logging.getLogger(__name__)
 
 _HAS_DOME = True  # Dome is always available — trust runtime lives inside vijil-dome.
+
+# A benign canned input the reachability probe runs through the guards. It is not
+# meant to trip any detector; success (no exception) means the backend responded.
+_DETECTOR_PROBE_INPUT = "ping"
+
+# How long a reachability result is reused before the probe runs the real
+# detectors again. Defaults at least as long as a typical heartbeat cadence so a
+# beacon does not run the backend on every emit. Overridable per instance.
+_DEFAULT_DETECTOR_PROBE_TTL_S = 60.0
+
+
+class _ProbeResult(NamedTuple):
+    """A cached detector-reachability result stamped with its monotonic time."""
+
+    at: float
+    reachable: bool
 
 
 class TrustRuntime:
@@ -179,6 +196,12 @@ class TrustRuntime:
         # ``seed_trust_vector()`` is called.
         self._trust_vector: TrustVector | None = None
         self._pending_deltas: list[tuple[str, TrustDelta]] = []
+
+        # 8. Detector-reachability probe state. The clock is injectable so the
+        # TTL cache can be tested without real time; production uses monotonic.
+        self._clock: Callable[[], float] = time.monotonic
+        self._detector_probe_ttl_s: float = _DEFAULT_DETECTOR_PROBE_TTL_S
+        self._detector_probe_cache: _ProbeResult | None = None
 
     # ------------------------------------------------------------------
     # Trust vector
@@ -657,6 +680,60 @@ class TrustRuntime:
     # Enforcement-alive heartbeat (B3)
     # ------------------------------------------------------------------
 
+    def _probe_detector_reachable(self) -> bool:
+        """Report whether the detector backend actually responds.
+
+        Distinct from ``guards_constructed``: True only when at least one
+        configured guardrail runs a canned input and no probed detector errors —
+        proving the backend (local models or a remote inference server) is live,
+        not merely that a Dome instance was built. The result is cached for
+        ``_detector_probe_ttl_s`` so the real detectors run at most once per
+        cadence; a backend that fails after a cached True therefore reads as
+        reachable until the entry expires (a bounded, configurable staleness).
+        """
+        if self._dome is None or self._guards_disabled:
+            return False
+        now = self._clock()
+        cached = self._detector_probe_cache
+        if cached is not None and (now - cached.at) < self._detector_probe_ttl_s:
+            return cached.reachable
+        reachable = self._run_detector_probe(self._dome)
+        self._detector_probe_cache = _ProbeResult(at=now, reachable=reachable)
+        return reachable
+
+    @staticmethod
+    def _run_detector_probe(dome: Any) -> bool:
+        """Run the canned input through each configured guardrail; True iff it responds.
+
+        Reachability is read from ``ScanResult.errored_methods``, NOT from a
+        raised exception: the guard engine catches a failing detector internally
+        and records it in ``errored_methods`` rather than propagating, so a
+        ``try/except`` around the call would miss a dead backend entirely. The
+        backend is reachable only when at least one guardrail is configured and
+        none of the probed detectors errored. The outer ``except`` covers
+        unexpected (non-detector) failures, which also mean not-reachable.
+
+        Blocking bound: each detector carries an internal per-call timeout, so a
+        guard with N detectors can block up to N×timeout. The heartbeat scheduler
+        (DOME-169) runs this off the request path so a slow probe degrades the
+        beacon cadence (itself detectable) rather than the agent's own latency.
+        """
+        probes: list[Callable[[str], Any]] = []
+        if dome.input_guardrail is not None:
+            probes.append(dome.guard_input)
+        if dome.output_guardrail is not None:
+            probes.append(dome.guard_output)
+        if not probes:
+            return False  # Dome built, but no guardrail with detectors to probe.
+        try:
+            for probe in probes:
+                if probe(_DETECTOR_PROBE_INPUT).errored_methods:
+                    return False  # a configured detector failed to respond
+        except Exception:  # noqa: BLE001 -- any unexpected failure means unreachable
+            logger.warning("detector reachability probe failed", exc_info=True)
+            return False
+        return True
+
     def emit_heartbeat(self) -> Heartbeat:
         """Emit an enforcement-alive beacon describing the live posture.
 
@@ -667,16 +744,18 @@ class TrustRuntime:
 
         ``guards_constructed`` is True when a Dome instance was successfully
         built; it proves construction, not that framework callbacks are wired.
-        ``detector_reachable`` is False when no guards are configured or when
-        the backend failed/was starved. ``attested`` gates the SPIFFE id:
-        ``agent_spiffe_id`` is only meaningful when ``attested`` is True.
+        ``detector_reachable`` is a live probe result (see
+        ``_probe_detector_reachable``): True only when the backend actually
+        responds, False when no guards are configured, guards are disabled, or
+        the probe fails. ``attested`` gates the SPIFFE id: ``agent_spiffe_id``
+        is only meaningful when ``attested`` is True.
 
-        A real detector reachability probe, SVID-signing, and periodic
-        scheduling are a follow-up (DOME-169).
+        SVID-signing of the beacon and periodic scheduling are wired by the
+        heartbeat scheduler (DOME-169).
         """
         attested = self._identity.is_attested()
         guards_constructed = self._dome is not None and not self._guards_disabled
-        detector_reachable = self._dome is not None and not self._guards_disabled
+        detector_reachable = self._probe_detector_reachable()
         heartbeat = Heartbeat(
             configured_mode=self.mode,
             guards_constructed=guards_constructed,

--- a/vijil_dome/trust/signing.py
+++ b/vijil_dome/trust/signing.py
@@ -136,9 +136,11 @@ class X509BeaconSigner:
 def verify_beacon_signature(beacon: Heartbeat, signature: BeaconSignature) -> bool:
     """Verify a detached beacon signature against the leaf cert it carries.
 
-    Confirms two things: (1) the leaf cert's SPIFFE SAN equals the beacon's
+    Confirms three things: (1) the leaf cert's SPIFFE SAN equals the beacon's
     ``agent_spiffe_id`` — without this, any holder of a valid SVID could sign a
-    beacon impersonating another agent; (2) the signature verifies under the
+    beacon impersonating another agent; (2) the envelope's self-asserted
+    ``signed_subject`` also equals ``agent_spiffe_id``, so a consumer reading it
+    off a verified signature can trust it; (3) the signature verifies under the
     leaf's public key over the canonical payload. Algorithm choice is driven by
     the cert's key type, NOT the attacker-supplied ``alg`` field, so an algorithm-
     confusion forgery cannot succeed.
@@ -154,6 +156,11 @@ def verify_beacon_signature(beacon: Heartbeat, signature: BeaconSignature) -> bo
         leaf = x509.load_pem_x509_certificate(signature.cert_chain[0].encode("utf-8"))
         cert_spiffe_id = _spiffe_id_from_cert(leaf)
         if cert_spiffe_id is None or cert_spiffe_id != beacon.agent_spiffe_id:
+            return False
+        # Reject an envelope whose self-asserted signed_subject disagrees with the
+        # beacon, so a consumer reading signed_subject off a *verified* signature
+        # can trust it equals agent_spiffe_id.
+        if signature.signed_subject != beacon.agent_spiffe_id:
             return False
         public_key = leaf.public_key()
         raw = base64.b64decode(signature.signature, validate=True)

--- a/vijil_dome/trust/signing.py
+++ b/vijil_dome/trust/signing.py
@@ -1,0 +1,170 @@
+"""Heartbeat beacon signing — the ``BeaconSigner`` seam (DOME-169).
+
+A signed beacon proves it was emitted by the attested principal it names, so a
+forged or replayed "I am enforcing" heartbeat fails verification downstream. The
+default :class:`UnwiredBeaconSigner` returns no signature (the beacon ships
+``signed=False``) for agents without an SVID; :class:`X509BeaconSigner` signs
+with the agent's SPIRE-issued X.509-SVID private key. Wiring the live signer to a
+real SVID and the Console-side trust-bundle chaining is deferred to DOME-179
+(cluster-gated); this module ships the seam plus a real, synthetic-key-tested
+sign/verify implementation that binds the signing cert to the claimed identity.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Protocol
+
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+from vijil_dome.trust.audit import BeaconSignature, Heartbeat
+
+# The identity-bearing fields a signature covers. The ``signature`` field itself
+# is excluded — you cannot sign over the signature.
+# A set (not frozenset) because Pydantic's ``model_dump(include=...)`` IncEx type
+# accepts ``set[str]``. Module-private and read-only in practice.
+_SIGNED_FIELDS: set[str] = {
+    "configured_mode",
+    "guards_constructed",
+    "detector_reachable",
+    "attested",
+    "agent_spiffe_id",
+}
+
+_PrivateKey = ec.EllipticCurvePrivateKey | rsa.RSAPrivateKey
+
+
+class _X509Svid(Protocol):
+    """The slice of a ``spiffe`` X509Svid that :meth:`X509BeaconSigner.from_svid` reads."""
+
+    private_key: _PrivateKey
+    leaf: x509.Certificate
+
+
+def canonical_beacon_payload(beacon: Heartbeat) -> bytes:
+    """Return a deterministic byte encoding of a beacon's identity-bearing fields.
+
+    Signer and verifier must agree on the exact bytes, so keys are sorted and
+    separators are fixed. ``model_dump(include=...)`` selects exactly the signed
+    fields (excluding ``signature``) and fails loud if the field set ever drifts
+    from the model. Cross-language note: Python ``json`` encodes ``bool`` as
+    ``true``/``false`` and ``None`` as ``null`` — a future non-Python verifier
+    must match this encoding.
+    """
+    content = beacon.model_dump(include=_SIGNED_FIELDS)
+    return json.dumps(content, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _spiffe_id_from_cert(cert: x509.Certificate) -> str | None:
+    """Extract the SPIFFE ID from a certificate's SAN URIs, or None if absent."""
+    try:
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    except x509.ExtensionNotFound:
+        return None
+    for uri in san.value.get_values_for_type(x509.UniformResourceIdentifier):
+        if uri.startswith("spiffe://"):
+            return uri
+    return None
+
+
+class BeaconSigner(Protocol):
+    """Signs an enforcement heartbeat, or declines when no SVID is available."""
+
+    def sign(self, beacon: Heartbeat) -> BeaconSignature | None: ...
+
+
+class UnwiredBeaconSigner:
+    """The honest default: no SVID, so no signature.
+
+    Returns ``None`` rather than fabricating a signature, so an unattested or
+    API-key agent's beacon ships ``signed=False`` instead of falsely signed.
+    """
+
+    def sign(self, beacon: Heartbeat) -> BeaconSignature | None:
+        return None
+
+
+class X509BeaconSigner:
+    """Signs a beacon with an X.509-SVID private key and leaf certificate."""
+
+    def __init__(self, private_key: _PrivateKey, leaf_cert: x509.Certificate) -> None:
+        self._private_key = private_key
+        self._leaf_cert = leaf_cert
+
+    @classmethod
+    def from_svid(cls, svid: _X509Svid) -> X509BeaconSigner:
+        """Build a signer from a ``spiffe`` X509Svid.
+
+        Reads ``.private_key`` and ``.leaf`` — the same attributes
+        ``AgentIdentity.mtls_context`` uses. Exercising this against a live SVID
+        is cluster-gated (DOME-179).
+        """
+        return cls(svid.private_key, svid.leaf)
+
+    def sign(self, beacon: Heartbeat) -> BeaconSignature | None:
+        if beacon.agent_spiffe_id is None:
+            # An unattested beacon names no principal, so a signature over it
+            # would attest nothing. Degrade to unsigned rather than emit a
+            # null-subject signature that a consumer might mistake for proof.
+            return None
+        payload = canonical_beacon_payload(beacon)
+        key = self._private_key
+        if isinstance(key, ec.EllipticCurvePrivateKey):
+            alg = "ES256"
+            raw = key.sign(payload, ec.ECDSA(hashes.SHA256()))
+        elif isinstance(key, rsa.RSAPrivateKey):
+            alg = "RS256"
+            raw = key.sign(payload, padding.PKCS1v15(), hashes.SHA256())
+        else:
+            raise TypeError(
+                f"unsupported SVID key type: {type(key).__name__}; expected EC or RSA"
+            )
+        leaf_pem = self._leaf_cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+        return BeaconSignature(
+            alg=alg,
+            signature=base64.b64encode(raw).decode("ascii"),
+            cert_chain=[leaf_pem],
+            signed_subject=beacon.agent_spiffe_id,
+        )
+
+
+def verify_beacon_signature(beacon: Heartbeat, signature: BeaconSignature) -> bool:
+    """Verify a detached beacon signature against the leaf cert it carries.
+
+    Confirms two things: (1) the leaf cert's SPIFFE SAN equals the beacon's
+    ``agent_spiffe_id`` — without this, any holder of a valid SVID could sign a
+    beacon impersonating another agent; (2) the signature verifies under the
+    leaf's public key over the canonical payload. Algorithm choice is driven by
+    the cert's key type, NOT the attacker-supplied ``alg`` field, so an algorithm-
+    confusion forgery cannot succeed.
+
+    Pure (no I/O). Returns ``False`` on any mismatch, malformed cert, or bad
+    base64 — never raises. Chaining the leaf to the trust bundle (proving the
+    cert is SPIRE-issued, not attacker-self-signed) is the Console's job
+    (DOME-179); this function alone does not establish that the SVID is genuine.
+    """
+    if not signature.cert_chain:
+        return False
+    try:
+        leaf = x509.load_pem_x509_certificate(signature.cert_chain[0].encode("utf-8"))
+        cert_spiffe_id = _spiffe_id_from_cert(leaf)
+        if cert_spiffe_id is None or cert_spiffe_id != beacon.agent_spiffe_id:
+            return False
+        public_key = leaf.public_key()
+        raw = base64.b64decode(signature.signature, validate=True)
+        payload = canonical_beacon_payload(beacon)
+        if isinstance(public_key, ec.EllipticCurvePublicKey):
+            public_key.verify(raw, payload, ec.ECDSA(hashes.SHA256()))
+        elif isinstance(public_key, rsa.RSAPublicKey):
+            public_key.verify(raw, payload, padding.PKCS1v15(), hashes.SHA256())
+        else:
+            return False
+    except (InvalidSignature, ValueError, UnsupportedAlgorithm):
+        # ValueError covers malformed PEM and bad base64 (binascii.Error);
+        # UnsupportedAlgorithm covers a leaf carrying a non-EC/RSA key type.
+        return False
+    return True

--- a/vijil_dome/trust/signing.py
+++ b/vijil_dome/trust/signing.py
@@ -50,10 +50,11 @@ def canonical_beacon_payload(beacon: Heartbeat) -> bytes:
 
     Signer and verifier must agree on the exact bytes, so keys are sorted and
     separators are fixed. ``model_dump(include=...)`` selects exactly the signed
-    fields (excluding ``signature``) and fails loud if the field set ever drifts
-    from the model. Cross-language note: Python ``json`` encodes ``bool`` as
-    ``true``/``false`` and ``None`` as ``null`` — a future non-Python verifier
-    must match this encoding.
+    fields (excluding ``signature``). ``_SIGNED_FIELDS`` must stay in sync with
+    ``Heartbeat``: a new identity-bearing field left out would ship unsigned and
+    tamperable, so ``test_signed_fields_match_heartbeat_model`` guards the drift.
+    Cross-language note: Python ``json`` encodes ``bool`` as ``true``/``false``
+    and ``None`` as ``null`` — a future non-Python verifier must match this.
     """
     content = beacon.model_dump(include=_SIGNED_FIELDS)
     return json.dumps(content, sort_keys=True, separators=(",", ":")).encode("utf-8")


### PR DESCRIPTION
## DOME-169: Enforcement-alive heartbeat — scheduler, real probe, signing seam

Arms B4's liveness reconciler by driving `emit_heartbeat()` on a self-monitoring cadence, reporting a **real** detector-reachability signal, and adding a beacon signing seam. Implements `docs/plans/2026-06-14-dome-169-heartbeat-scheduler-plan.md`.

### What landed (5 commits, hexagonal order)
- **Domain** — `BeaconSigner` seam: `UnwiredBeaconSigner` default (`signed=False`), real `X509BeaconSigner` (ECDSA/RSA over canonical beacon JSON), and `verify_beacon_signature` that binds the leaf cert's SPIFFE SAN to the beacon's `agent_spiffe_id` (anti-impersonation). New `Heartbeat.signature` field.
- **Application** — real `detector_reachable` probe (reads `errored_methods`, probes whichever guardrail is configured, TTL-cached); supervised daemon-thread scheduler with `start_heartbeat`/`stop_heartbeat` + `heartbeat_health()` in-process liveness so a dead/stalled loop is detectable WITHOUT the Console reconciler.
- **Adapter** — `heartbeat_interval`/`beacon_signer` threaded through `secure_agent` and all three adapters (LangGraph/ADK/Strands; LangGraph does **not** get it free — its `**compile_kwargs` route to `graph.compile()`).
- **Test** — end-to-end: real loop emits signed beacons that verify; a tampered (downgraded) beacon fails verification e2e; unsigned default; detector-unreachable.

### Design divergence (surfaced, not silent)
The design's B3 says "SVID-signed now." This ships the signing **seam** + a synthetic-key-tested `X509BeaconSigner`, but the **default is `UnwiredBeaconSigner` (`signed=False`)** because the X.509 key only exists under live SPIRE attestation (cluster-gated). Wiring the live signer + Console-side verification is tracked in **DOME-179**.

### Gates
- `poetry run pytest vijil_dome/tests/trust/` — 286 passed, 2 skipped (pre-existing model-availability skips)
- `make lint` (ruff + mypy, src + tests) — clean
- Per-task: steelman (2 reviewers) + silent-failure-hunter + per-task review on every commit; all REVISE findings fixed and re-reviewed to PASS. Notable catches: the probe must read `errored_methods` not exceptions (an exception-only probe reports a dead backend as alive); SAN-binding in verify; hung-join thread-orphan; all-three-adapter threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)