### PR TITLE
fix(detectors): standardize generic-LLM judge on groq/openai/gpt-oss-120b

### DIFF
--- a/vijil_dome/defaults.py
+++ b/vijil_dome/defaults.py
@@ -54,8 +54,8 @@ def get_default_config():
     return DefaultDomeConfig().default_guardrail_config
 
 
-DEFAULT_LLM_MODEL: str = os.environ.get("VIJIL_LLM_MODEL") or "gpt-4-turbo"
-DEFAULT_LLM_HUB: str = os.environ.get("VIJIL_LLM_HUB") or "openai"
+DEFAULT_LLM_MODEL: str = os.environ.get("VIJIL_LLM_MODEL") or "groq/openai/gpt-oss-120b"
+DEFAULT_LLM_HUB: str = os.environ.get("VIJIL_LLM_HUB") or "groq"
 DEFAULT_SAFEGUARD_MODEL: str = (
     os.environ.get("VIJIL_SAFEGUARD_MODEL") or "openai/gpt-oss-safeguard-20b"
 )

--- a/vijil_dome/detectors/DETECTOR_INFO.md
+++ b/vijil_dome/detectors/DETECTOR_INFO.md
@@ -139,8 +139,8 @@ LLM-based security classification via LiteLLM.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `hub_name` | `str` | `"openai"` | LLM API provider |
-| `model_name` | `str` | `"gpt-4-turbo"` | Model name |
+| `hub_name` | `str` | `"groq"` | LLM API provider |
+| `model_name` | `str` | `"groq/openai/gpt-oss-120b"` | Model name |
 | `api_key` | `str` | `None` | API key (falls back to env var) |
 | `max_input_chars` | `int` | `None` | Truncate input to this many characters |
 
@@ -353,8 +353,8 @@ LLM-based moderation classification via LiteLLM.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `hub_name` | `str` | `"openai"` | LLM API provider |
-| `model_name` | `str` | `"gpt-4-turbo"` | Model name |
+| `hub_name` | `str` | `"groq"` | LLM API provider |
+| `model_name` | `str` | `"groq/openai/gpt-oss-120b"` | Model name |
 | `api_key` | `str` | `None` | API key (falls back to env var) |
 | `max_input_chars` | `int` | `None` | Truncate input to this many characters |
 
@@ -534,8 +534,8 @@ LLM-based hallucination detection with reference context.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `hub_name` | `str` | `"openai"` | LLM API provider |
-| `model_name` | `str` | `"gpt-4-turbo"` | Model name |
+| `hub_name` | `str` | `"groq"` | LLM API provider |
+| `model_name` | `str` | `"groq/openai/gpt-oss-120b"` | Model name |
 | `api_key` | `str` | `None` | API key (falls back to env var) |
 | `max_input_chars` | `int` | `None` | Truncate input to this many characters |
 | `context` | `str` | `None` | Reference context for comparison |
@@ -548,8 +548,8 @@ LLM-based fact-checking with reference context.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `hub_name` | `str` | `"openai"` | LLM API provider |
-| `model_name` | `str` | `"gpt-4-turbo"` | Model name |
+| `hub_name` | `str` | `"groq"` | LLM API provider |
+| `model_name` | `str` | `"groq/openai/gpt-oss-120b"` | Model name |
 | `api_key` | `str` | `None` | API key (falls back to env var) |
 | `max_input_chars` | `int` | `None` | Truncate input to this many characters |
 | `context` | `str` | `None` | Reference context for comparison |
@@ -570,8 +570,8 @@ Custom LLM-based detection with user-provided system prompts and trigger words.
 |-----------|------|---------|-------------|
 | `sys_prompt_template` | `str` | *(required)* | System prompt with `$query_string` placeholder |
 | `trigger_word_list` | `list[str]` | *(required)* | Words in LLM response that indicate a hit |
-| `hub_name` | `str` | `"openai"` | LLM API provider |
-| `model_name` | `str` | `"gpt-4-turbo"` | Model name |
+| `hub_name` | `str` | `"groq"` | LLM API provider |
+| `model_name` | `str` | `"groq/openai/gpt-oss-120b"` | Model name |
 | `api_key` | `str` | `None` | API key (falls back to env var) |
 | `max_input_chars` | `int` | `None` | Truncate input to this many characters |
 

--- a/vijil_dome/tests/test_defaults.py
+++ b/vijil_dome/tests/test_defaults.py
@@ -16,8 +16,8 @@ class TestCentralizedConstants:
             DEFAULT_SAFEGUARD_MODEL,
         )
 
-        expected_model = os.environ.get("VIJIL_LLM_MODEL") or "gpt-4-turbo"
-        expected_hub = os.environ.get("VIJIL_LLM_HUB") or "openai"
+        expected_model = os.environ.get("VIJIL_LLM_MODEL") or "groq/openai/gpt-oss-120b"
+        expected_hub = os.environ.get("VIJIL_LLM_HUB") or "groq"
         expected_safeguard = (
             os.environ.get("VIJIL_SAFEGUARD_MODEL") or "openai/gpt-oss-safeguard-20b"
         )


### PR DESCRIPTION
## What

Standardize Dome's **generic LLM-as-judge** detectors (security-llm, moderation-llm, hallucination-llm, fact-check-llm, generic-llm) on `groq/openai/gpt-oss-120b`, replacing `openai/gpt-4-turbo`. This is the model Diamond (all LLM detectors) and vijil-bar (the calibrated judges) already run — the platform's LLM-judge tier is now consistent.

## Change

- `defaults.py`: `DEFAULT_LLM_MODEL "gpt-4-turbo" → "groq/openai/gpt-oss-120b"`, `DEFAULT_LLM_HUB "openai" → "groq"`.
- `test_defaults.py` + `DETECTOR_INFO.md` (5 generic-LLM entries) updated to match.

## Why the `groq/` prefix (functional detail)

Dome's `hub="groq"` branch sets `base_url=""` and relies on **litellm's native Groq routing** (`llm_api_base.py:56-58`, comment "LiteLLM has native Groq support") — unlike the *safeguard* detectors, which reach Groq via an explicit `base_url`. So the generic-LLM model string needs the `groq/` provider prefix. Verified the string routes to Groq via litellm (the call reached a `GroqException`, i.e. correct provider — it didn't misroute to OpenAI).

## Scope

- **Fast classifier / safeguard model (`openai/gpt-oss-safeguard-20b`) is unchanged** — the 20b safety-tuned gate stays as-is.
- Env overrides `VIJIL_LLM_MODEL` / `VIJIL_LLM_HUB` still apply.

Part of a cross-repo judge-model standardization (Darwin #204 for PolicyViolation; Swarm to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)